### PR TITLE
Storing metadata as regular data

### DIFF
--- a/kv_store/include/common.h
+++ b/kv_store/include/common.h
@@ -11,6 +11,17 @@
 
 using namespace std;
 
+// Define monitoring constant
+#define STORAGE_CONSUMPTION_REPORT_THRESHOLD 10
+#define HOTNESS_MONITORING_THRESHOLD 30
+#define HOTNESS_MONITORING_PERIOD 10
+
+// Define the replication factor for the metadata
+#define METADATA_REPLICATION_FACTOR 2
+
+// Define the number of ebs threads
+#define EBS_THREAD_NUM 3
+
 // Define the number of proxy worker threads
 #define PROXY_THREAD_NUM 16
 
@@ -18,7 +29,7 @@ using namespace std;
 #define SERVER_PORT 6560
 #define PROXY_CONNECTION_BASE_PORT 6460
 #define NOTIFY_PORT 7060
-#define PROXY_USER_PORT 7160
+#define PROXY_REQUEST_PORT 7160
 #define PROXY_GOSSIP_PORT 7260
 #define PROXY_PLACEMENT_PORT 7360
 #define PROXY_BENCHMARK_PORT 7460
@@ -129,16 +140,16 @@ class proxy_worker_thread_t {
 public:
   proxy_worker_thread_t() {}
   proxy_worker_thread_t(string ip, int tid): ip_(ip) {
-    user_request_connect_addr_ = "tcp://" + ip + ":" + to_string(tid + PROXY_USER_PORT);
-    user_request_bind_addr_ = "tcp://*:" + to_string(tid + PROXY_USER_PORT);
+    request_connect_addr_ = "tcp://" + ip + ":" + to_string(tid + PROXY_REQUEST_PORT);
+    request_bind_addr_ = "tcp://*:" + to_string(tid + PROXY_REQUEST_PORT);
     proxy_gossip_connect_addr_ = "tcp://" + ip + ":" + to_string(tid + PROXY_GOSSIP_PORT);
     proxy_gossip_bind_addr_ = "tcp://*:" + to_string(tid + PROXY_GOSSIP_PORT);
     banchmark_connect_addr_ = "tcp://" + ip + ":" + to_string(tid + PROXY_BENCHMARK_PORT);
     banchmark_bind_addr_ = "tcp://*:" + to_string(tid + PROXY_BENCHMARK_PORT);
   }
   string ip_;
-  string user_request_connect_addr_;
-  string user_request_bind_addr_;
+  string request_connect_addr_;
+  string request_bind_addr_;
   string proxy_gossip_connect_addr_;
   string proxy_gossip_bind_addr_;
   string banchmark_connect_addr_;

--- a/kv_store/include/common.h
+++ b/kv_store/include/common.h
@@ -17,13 +17,13 @@ using namespace std;
 #define HOTNESS_MONITORING_PERIOD 10
 
 // Define the replication factor for the metadata
-#define METADATA_REPLICATION_FACTOR 2
+#define METADATA_REPLICATION_FACTOR 1
 
 // Define the number of ebs threads
 #define EBS_THREAD_NUM 3
 
 // Define the number of proxy worker threads
-#define PROXY_THREAD_NUM 16
+#define PROXY_THREAD_NUM 1
 
 // Define port offset
 #define SERVER_PORT 6560
@@ -33,6 +33,7 @@ using namespace std;
 #define PROXY_GOSSIP_PORT 7260
 #define PROXY_PLACEMENT_PORT 7360
 #define PROXY_BENCHMARK_PORT 7460
+#define PROXY_METADATA_PORT 7560
 #define STORAGE_CONSUMPTION_PORT 7460
 #define KEY_HOTNESS_PORT 7560
 #define REPLICATION_FACTOR_PORT 6360
@@ -146,6 +147,8 @@ public:
     proxy_gossip_bind_addr_ = "tcp://*:" + to_string(tid + PROXY_GOSSIP_PORT);
     banchmark_connect_addr_ = "tcp://" + ip + ":" + to_string(tid + PROXY_BENCHMARK_PORT);
     banchmark_bind_addr_ = "tcp://*:" + to_string(tid + PROXY_BENCHMARK_PORT);
+    metadata_connect_addr_ = "tcp://" + ip + ":" + to_string(tid + PROXY_METADATA_PORT);
+    metadata_bind_addr_ = "tcp://*:" + to_string(tid + PROXY_METADATA_PORT);
   }
   string ip_;
   string request_connect_addr_;
@@ -154,6 +157,8 @@ public:
   string proxy_gossip_bind_addr_;
   string banchmark_connect_addr_;
   string banchmark_bind_addr_;
+  string metadata_connect_addr_;
+  string metadata_bind_addr_;
 };
 
 class monitoring_node_t {

--- a/kv_store/include/server_utility.h
+++ b/kv_store/include/server_utility.h
@@ -3,8 +3,6 @@
 
 #include <string>
 
-#define STORAGE_CONSUMPTION_REPORT_THRESHOLD 10
-
 using namespace std;
 
 string alphabet("abcdefghijklmnopqrstuvwxyz");
@@ -67,7 +65,7 @@ pair<bool, N*> responsible(string key, int rep, consistent_hash_map<N,H>& hash_r
 }
 
 template<typename T>
-communication::Key_Response get_key_address(string target_node_address, string target_tier, unordered_set<string> keys, SocketCache& key_address_requesters, unordered_map<string, T> placement) {
+communication::Key_Response get_key_address(string target_node_address, string target_tier, unordered_set<string> keys, SocketCache& requesters, unordered_map<string, T> placement) {
   // form key address request
   communication::Key_Request req;
   req.set_sender("server");
@@ -85,9 +83,9 @@ communication::Key_Response get_key_address(string target_node_address, string t
   string key_req;
   req.SerializeToString(&key_req);
   // send key address request
-  zmq_util::send_string(key_req, &key_address_requesters[target_node_address]);
+  zmq_util::send_string(key_req, &requesters[target_node_address]);
   // receive key address response
-  string key_res = zmq_util::recv_string(&key_address_requesters[target_node_address]);
+  string key_res = zmq_util::recv_string(&requesters[target_node_address]);
 
   communication::Key_Response resp;
   resp.ParseFromString(key_res);

--- a/kv_store/lww_kvs/CMakeLists.txt
+++ b/kv_store/lww_kvs/CMakeLists.txt
@@ -20,7 +20,7 @@ SET(KV_SRC_DEPENDENCIES
     ${PROTO_HEADER}
 )
 
-ADD_EXECUTABLE(kvs_user kvs_user.cpp ../include/zmq_util.cc ../include/zmq_util.h)
+ADD_EXECUTABLE(kvs_user kvs_user.cpp ${KV_SRC_DEPENDENCIES} ../include/zmq_util.cc ../include/zmq_util.h)
 TARGET_LINK_LIBRARIES(kvs_user ${KV_LIBRARY_DEPENDENCIES})
 
 ADD_EXECUTABLE(kvs_benchmark kvs_benchmark.cpp ../include/zmq_util.cc ../include/zmq_util.h ../include/socket_cache.cc ../include/socket_cache.h)

--- a/kv_store/lww_kvs/kvs_ebs_server.cpp
+++ b/kv_store/lww_kvs/kvs_ebs_server.cpp
@@ -24,10 +24,10 @@
 using namespace std;
 
 // If the total number of updates to the kvs before the last gossip reaches THRESHOLD, then the thread gossips to others.
-#define THRESHOLD 100
+#define THRESHOLD 1000
 
 // Define the gossip period (frequency)
-#define PERIOD 5
+#define PERIOD 10
 
 // Define the default local ebs replication factor
 #define DEFAULT_LOCAL_EBS_REPLICATION 1
@@ -1307,8 +1307,7 @@ int main(int argc, char* argv[]) {
       string proxy_ip = *(proxy_address.begin());
       // randomly choose a proxy thread to connect
       int tid = 1 + rand() % PROXY_THREAD_NUM;
-      zmq_util::send_string(serialized_req, &requesters[proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_]);
-      zmq_util::recv_string(&requesters[proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_]);
+      zmq_util::send_string(serialized_req, &pushers[proxy_worker_thread_t(proxy_ip, tid).metadata_connect_addr_]);
 
       storage_start = std::chrono::system_clock::now();
     }

--- a/kv_store/lww_kvs/kvs_memory_server.cpp
+++ b/kv_store/lww_kvs/kvs_memory_server.cpp
@@ -98,24 +98,26 @@ void process_memory_remove(string key, Database* kvs) {
 string process_proxy_request(communication::Request& req, int thread_id, unordered_set<string>& local_changeset, Database* kvs) {
   communication::Response response;
 
-  if (req.get_size() != 0) {
+  if (req.type() == "GET") {
     //cout << "received get by thread " << thread_id << "\n";
-    for (int i = 0; i < req.get_size(); i++) {
-      auto res = process_memory_get(req.get(i).key(), kvs);
+    response.set_type("GET");
+    for (int i = 0; i < req.tuple_size(); i++) {
+      auto res = process_memory_get(req.tuple(i).key(), kvs);
       communication::Response_Tuple* tp = response.add_tuple();
-      tp->set_key(req.get(i).key());
+      tp->set_key(req.tuple(i).key());
       tp->set_value(res.first.reveal().value);
       tp->set_timestamp(res.first.reveal().timestamp);
       tp->set_succeed(res.second);
     }
-  } else if (req.put_size() != 0) {
+  } else if (req.type() == "PUT") {
     //cout << "received put by thread " << thread_id << "\n";
-    for (int i = 0; i < req.put_size(); i++) {
-      bool succeed = process_memory_put(req.put(i).key(), lww_timestamp.load(), req.put(i).value(), kvs);
+    response.set_type("PUT");
+    for (int i = 0; i < req.tuple_size(); i++) {
+      bool succeed = process_memory_put(req.tuple(i).key(), lww_timestamp.load(), req.tuple(i).value(), kvs);
       communication::Response_Tuple* tp = response.add_tuple();
-      tp->set_key(req.put(i).key());
+      tp->set_key(req.tuple(i).key());
       tp->set_succeed(succeed);
-      local_changeset.insert(req.put(i).key());
+      local_changeset.insert(req.tuple(i).key());
     }
   }
   
@@ -131,7 +133,7 @@ void process_distributed_gossip(communication::Gossip& gossip, int thread_id, Da
   }
 }
 
-void send_gossip(changeset_address* change_set_addr, SocketCache& cache, string ip, int thread_id, Database* kvs) {
+void send_gossip(changeset_address* change_set_addr, SocketCache& pushers, string ip, int thread_id, Database* kvs) {
   unordered_map<string, communication::Gossip> distributed_gossip_map;
 
   for (auto map_it = change_set_addr->begin(); map_it != change_set_addr->end(); map_it++) {
@@ -156,7 +158,7 @@ void send_gossip(changeset_address* change_set_addr, SocketCache& cache, string 
   for (auto it = distributed_gossip_map.begin(); it != distributed_gossip_map.end(); it++) {
     string data;
     it->second.SerializeToString(&data);
-    zmq_util::send_string(data, &cache[it->first]);
+    zmq_util::send_string(data, &pushers[it->first]);
   }
 }
 
@@ -183,7 +185,7 @@ void memory_worker_routine (zmq::context_t* context, Database* kvs, string ip, i
   changeset_address_requester.connect(CHANGESET_ADDR);
 
   // used to send gossip
-  SocketCache cache(context, ZMQ_PUSH);
+  SocketCache pushers(context, ZMQ_PUSH);
 
   //  Initialize poll set
   vector<zmq::pollitem_t> pollitems = {
@@ -243,7 +245,7 @@ void memory_worker_routine (zmq::context_t* context, Database* kvs, string ip, i
           }
         }
       }
-      send_gossip(&c_address, cache, ip, thread_id, kvs);
+      send_gossip(&c_address, pushers, ip, thread_id, kvs);
       delete r_data;
       // remove keys in the remove set
       for (auto it = remove_set.begin(); it != remove_set.end(); it++) {
@@ -268,7 +270,7 @@ void memory_worker_routine (zmq::context_t* context, Database* kvs, string ip, i
         zmq::message_t msg;
         zmq_util::recv_msg(&changeset_address_requester, msg);
         changeset_address* res = *(changeset_address **)(msg.data());
-        send_gossip(res, cache, ip, thread_id, kvs);
+        send_gossip(res, pushers, ip, thread_id, kvs);
         delete res;
         local_changeset.clear();
       }
@@ -298,9 +300,8 @@ int main(int argc, char* argv[]) {
   //  Prepare our context
   zmq::context_t context(1);
 
-  SocketCache cache(&context, ZMQ_PUSH);
-
-  SocketCache key_address_requesters(&context, ZMQ_REQ);
+  SocketCache pushers(&context, ZMQ_PUSH);
+  SocketCache requesters(&context, ZMQ_REQ);
 
   global_hash_t global_memory_hash_ring;
 
@@ -373,19 +374,19 @@ int main(int argc, char* argv[]) {
     // notify other servers
     for (auto it = global_memory_hash_ring.begin(); it != global_memory_hash_ring.end(); it++) {
       if (it->second.ip_.compare(ip) != 0) {
-        zmq_util::send_string(ip, &cache[(it->second).node_join_connect_addr_]);
+        zmq_util::send_string(ip, &pushers[(it->second).node_join_connect_addr_]);
       }
     }
   }
 
   // notify proxies
   for (auto it = proxy_address.begin(); it != proxy_address.end(); it++) {
-    zmq_util::send_string("join:M:" + ip, &cache[proxy_node_t(*it).notify_connect_addr_]);
+    zmq_util::send_string("join:M:" + ip, &pushers[proxy_node_t(*it).notify_connect_addr_]);
   }
 
   // notify monitoring nodes
   for (auto it = monitoring_address.begin(); it != monitoring_address.end(); it++) {
-    zmq_util::send_string("join:M:" + ip, &cache[monitoring_node_t(*it).notify_connect_addr_]);
+    zmq_util::send_string("join:M:" + ip, &pushers[monitoring_node_t(*it).notify_connect_addr_]);
   }
 
   // (seed node) responsible for sending the server address to the new node
@@ -466,7 +467,7 @@ int main(int argc, char* argv[]) {
         }
       }
 
-      communication::Key_Response resp = get_key_address<key_info>(new_node.key_exchange_connect_addr_, "", key_to_query, key_address_requesters, placement);
+      communication::Key_Response resp = get_key_address<key_info>(new_node.key_exchange_connect_addr_, "", key_to_query, requesters, placement);
 
       redistribution_address* r_address = new redistribution_address();
       // for each key in the response
@@ -477,7 +478,7 @@ int main(int argc, char* argv[]) {
         (*r_address)[target_address].insert(pair<string, bool>(key, true));
       }
 
-      zmq_util::send_msg((void*)r_address, &cache[worker_address]);
+      zmq_util::send_msg((void*)r_address, &pushers[worker_address]);
     }
 
     if (pollitems[2].revents & ZMQ_POLLIN) {
@@ -564,7 +565,7 @@ int main(int argc, char* argv[]) {
       }
       for (auto map_iter = node_map.begin(); map_iter != node_map.end(); map_iter++) {
         // get key address
-        communication::Key_Response resp = get_key_address<key_info>(map_iter->first.key_exchange_connect_addr_, "", map_iter->second, key_address_requesters, placement);
+        communication::Key_Response resp = get_key_address<key_info>(map_iter->first.key_exchange_connect_addr_, "", map_iter->second, requesters, placement);
 
         // for each key in the response
         for (int i = 0; i < resp.tuple_size(); i++) {
@@ -581,7 +582,7 @@ int main(int argc, char* argv[]) {
         int tid = 1 + rand() % PROXY_THREAD_NUM;
         string target_proxy_address = proxy_worker_thread_t(proxy_address[rand() % proxy_address.size()], tid).proxy_gossip_connect_addr_;
         // get key address
-        communication::Key_Response resp = get_key_address<key_info>(target_proxy_address, "E", key_to_proxy, key_address_requesters, placement);
+        communication::Key_Response resp = get_key_address<key_info>(target_proxy_address, "E", key_to_proxy, requesters, placement);
 
         // for each key, add the address of *every* (there can be multiple)
         // worker thread on the other node that should receive this key
@@ -600,11 +601,11 @@ int main(int argc, char* argv[]) {
       //cout << "Node is departing.\n";
       global_memory_hash_ring.erase(mnode);
       for (auto it = global_memory_hash_ring.begin(); it != global_memory_hash_ring.end(); it++) {
-        zmq_util::send_string(ip, &cache[it->second.node_depart_connect_addr_]);
+        zmq_util::send_string(ip, &pushers[it->second.node_depart_connect_addr_]);
       }
       // notify proxies
       for (auto it = proxy_address.begin(); it != proxy_address.end(); it++) {
-        zmq_util::send_string("depart:M:" + ip, &cache[proxy_node_t(*it).notify_connect_addr_]);
+        zmq_util::send_string("depart:M:" + ip, &pushers[proxy_node_t(*it).notify_connect_addr_]);
       }
       // form the key_request map
       unordered_map<string, communication::Key_Request> key_request_map;
@@ -630,8 +631,8 @@ int main(int argc, char* argv[]) {
       for (auto it = key_request_map.begin(); it != key_request_map.end(); it++) {
         string key_req;
         it->second.SerializeToString(&key_req);
-        zmq_util::send_string(key_req, &key_address_requesters[it->first]);
-        string key_res = zmq_util::recv_string(&key_address_requesters[it->first]);
+        zmq_util::send_string(key_req, &requesters[it->first]);
+        string key_res = zmq_util::recv_string(&requesters[it->first]);
 
         communication::Key_Response resp;
         resp.ParseFromString(key_res);
@@ -644,7 +645,7 @@ int main(int argc, char* argv[]) {
           (*r_address)[target_address].insert(pair<string, bool>(key, true));
         }
       }
-      zmq_util::send_msg((void*)r_address, &cache[worker_address]);
+      zmq_util::send_msg((void*)r_address, &pushers[worker_address]);
       // TODO: once we break here, I don't think that the threads will have
       // finished. they will still be looping.
       break;
@@ -716,7 +717,7 @@ int main(int argc, char* argv[]) {
 
       for (auto map_iter = node_map.begin(); map_iter != node_map.end(); map_iter++) {
         // get key address
-        communication::Key_Response resp = get_key_address<key_info>(map_iter->first.key_exchange_connect_addr_, "", map_iter->second, key_address_requesters, placement);
+        communication::Key_Response resp = get_key_address<key_info>(map_iter->first.key_exchange_connect_addr_, "", map_iter->second, requesters, placement);
 
         // for each key in the response
         for (int i = 0; i < resp.tuple_size(); i++) {
@@ -733,7 +734,7 @@ int main(int argc, char* argv[]) {
         int tid = 1 + rand() % PROXY_THREAD_NUM;
         string target_proxy_address = proxy_worker_thread_t(proxy_address[rand() % proxy_address.size()], tid).proxy_gossip_connect_addr_;
         // get key address
-        communication::Key_Response resp = get_key_address<key_info>(target_proxy_address, "E", key_to_proxy, key_address_requesters, placement);
+        communication::Key_Response resp = get_key_address<key_info>(target_proxy_address, "E", key_to_proxy, requesters, placement);
 
         // for each key, add the address of *every* (there can be multiple)
         // worker thread on the other node that should receive this key
@@ -744,7 +745,7 @@ int main(int argc, char* argv[]) {
         }
       }
 
-      zmq_util::send_msg((void*)r_address, &cache[worker_address]);
+      zmq_util::send_msg((void*)r_address, &pushers[worker_address]);
     }
 
     storage_end = std::chrono::system_clock::now();
@@ -756,24 +757,25 @@ int main(int argc, char* argv[]) {
         consumption += it->second->load();
       }
 
-      // compute worker thread occupancy
-      int occupied = 0;
-      for (int i = 0; i < MEMORY_THREAD_NUM; i++) {
-        if (worker_thread_status[i].load() == true) {
-          occupied += 1;
-        }
-      }
+      communication::Request req;
+      req.set_type("PUT");
+      req.set_metadata(true);
 
-      communication::Storage_Update su;
-      su.set_node_ip(mnode.ip_);
-      su.set_node_type("M");
-      su.set_memory_storage(consumption);
-      su.set_thread_occupancy(float(occupied) / MEMORY_THREAD_NUM);
-      string msg;
-      su.SerializeToString(&msg);
+      communication::Request_Tuple* tp = req.add_tuple();
+      tp->set_key(mnode.ip_ + "_storage");
+      tp->set_value(to_string(consumption));
 
-      // send the storage consumption update
-      zmq_util::send_string(msg, &cache[monitoring_node.storage_consumption_connect_addr_]);
+      string serialized_req;
+      req.SerializeToString(&serialized_req);
+
+      // send the storage consumption update to a random proxy worker
+      // just pick the first proxy to contact for now;
+      // this should eventually be round-robin / random
+      string proxy_ip = *(proxy_address.begin());
+      // randomly choose a proxy thread to connect
+      int tid = 1 + rand() % PROXY_THREAD_NUM;
+      zmq_util::send_string(serialized_req, &requesters[proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_]);
+      zmq_util::recv_string(&requesters[proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_]);
 
       storage_start = std::chrono::system_clock::now();
     }

--- a/kv_store/lww_kvs/kvs_monitoring.cpp
+++ b/kv_store/lww_kvs/kvs_monitoring.cpp
@@ -153,12 +153,12 @@ int main(int argc, char* argv[]) {
   address.close();
 
   // read address of management node from conf file
-  /*address_t management_address;
+  address_t management_address;
 
   address.open("conf/monitoring/management_ip.txt");
   getline(address, ip_line);
   management_address = ip_line;
-  address.close();*/
+  address.close();
 
 
   zmq::context_t context(1);
@@ -336,7 +336,7 @@ int main(int argc, char* argv[]) {
         }
       }
 
-      /*size_t total_memory_consumption = 0;
+      size_t total_memory_consumption = 0;
       size_t total_ebs_consumption = 0;
       int memory_node_count = 0;
       int ebs_volume_count = 0;
@@ -363,7 +363,7 @@ int main(int argc, char* argv[]) {
         cerr << "trigger add ebs node\n";
         string shell_command = "curl -X POST https://" + management_address + "/ebs";
         system(shell_command.c_str());
-      }*/
+      }
 
       storage_start = std::chrono::system_clock::now();
     }

--- a/kv_store/lww_kvs/kvs_monitoring.cpp
+++ b/kv_store/lww_kvs/kvs_monitoring.cpp
@@ -115,14 +115,11 @@ int main(int argc, char* argv[]) {
   // keep track of the keys' hotness
   unordered_map<string, unordered_map<address_t, size_t>> key_access_frequency;
 
-  // keep track of memory tier worker thread occupancy
-  unordered_map<master_node_t, float, node_hash> memory_tier_occupancy;
-
   // keep track of memory tier storage consumption
-  unordered_map<master_node_t, size_t, node_hash> memory_tier_storage;
+  unordered_map<address_t, size_t> memory_tier_storage;
 
   // keep track of ebs tier storage consumption
-  unordered_map<master_node_t, unordered_map<string, size_t>, node_hash> ebs_tier_storage;
+  unordered_map<address_t, unordered_map<string, size_t>> ebs_tier_storage;
  
   // read in the initial server addresses and build the hash ring
   string ip_line;
@@ -166,6 +163,9 @@ int main(int argc, char* argv[]) {
 
   zmq::context_t context(1);
 
+  SocketCache pushers(&context, ZMQ_PUSH);
+  SocketCache requesters(&context, ZMQ_REQ);
+
   // responsible for both node join and departure
   zmq::socket_t join_puller(context, ZMQ_PULL);
   join_puller.bind(NOTIFY_BIND_ADDR);
@@ -174,20 +174,16 @@ int main(int argc, char* argv[]) {
   zmq::socket_t replication_factor_query_responder(context, ZMQ_REP);
   replication_factor_query_responder.bind(REPLICATION_FACTOR_BIND_ADDR);
 
-  // responsible for receiving storage consumption updates from server nodes
-  zmq::socket_t storage_consumption_puller(context, ZMQ_PULL);
-  storage_consumption_puller.bind(STORAGE_CONSUMPTION_BIND_ADDR);
-
-  // responsible for receiving key hotness updates
-  zmq::socket_t key_hotness_puller(context, ZMQ_PULL);
-  key_hotness_puller.bind(KEY_HOTNESS_BIND_ADDR);
-
   vector<zmq::pollitem_t> pollitems = {
     { static_cast<void *>(join_puller), 0, ZMQ_POLLIN, 0 },
-    { static_cast<void *>(replication_factor_query_responder), 0, ZMQ_POLLIN, 0 },
-    { static_cast<void *>(storage_consumption_puller), 0, ZMQ_POLLIN, 0 },
-    { static_cast<void *>(key_hotness_puller), 0, ZMQ_POLLIN, 0 }
+    { static_cast<void *>(replication_factor_query_responder), 0, ZMQ_POLLIN, 0 }
   };
+
+  auto hotness_start = std::chrono::system_clock::now();
+  auto hotness_end = std::chrono::system_clock::now();
+
+  auto storage_start = std::chrono::system_clock::now();
+  auto storage_end = std::chrono::system_clock::now();
 
   while (true) {
     // listen for ZMQ events
@@ -204,6 +200,8 @@ int main(int argc, char* argv[]) {
           global_memory_hash_ring.insert(master_node_t(v[2], "M"));
         } else if (v[1] == "E") {
           global_ebs_hash_ring.insert(master_node_t(v[2], "E"));
+        } else if (v[1] == "P") {
+          proxy_address.push_back(v[2]);
         } else {
           cerr << "Invalid Tier info\n";
         }
@@ -214,10 +212,10 @@ int main(int argc, char* argv[]) {
         // update hash ring
         if (v[1] == "M") {
           global_memory_hash_ring.erase(master_node_t(v[2], "M"));
-          memory_tier_storage.erase(master_node_t(v[2], "M"));
+          memory_tier_storage.erase(v[2]);
         } else if (v[1] == "E") {
           global_ebs_hash_ring.erase(master_node_t(v[2], "E"));
-          ebs_tier_storage.erase(master_node_t(v[2], "E"));
+          ebs_tier_storage.erase(v[2]);
         } else {
           cerr << "Invalid Tier info\n";
         }
@@ -245,14 +243,138 @@ int main(int argc, char* argv[]) {
       zmq_util::send_string(response, &replication_factor_query_responder);
     }
 
-    if (pollitems[2].revents & ZMQ_POLLIN) {
+    hotness_end = std::chrono::system_clock::now();
+
+    if (chrono::duration_cast<std::chrono::seconds>(hotness_end-hotness_start).count() >= HOTNESS_MONITORING_PERIOD) {
+      // fetch key hotness data from the storage tier
+      communication::Request req;
+      req.set_type("GET");
+      req.set_metadata(true);
+
+      for (auto it = placement.begin(); it != placement.end(); it++) {
+        for (auto iter = proxy_address.begin(); iter != proxy_address.end(); iter++) {
+          communication::Request_Tuple* tp = req.add_tuple();
+          tp->set_key(it->first + "_" + *iter + "_hotness");
+        }
+      }
+
+      string serialized_req;
+      req.SerializeToString(&serialized_req);
+      // send the storage consumption update to a random proxy worker
+      // just pick the first proxy to contact for now;
+      // this should eventually be round-robin / random
+      string proxy_ip = *(proxy_address.begin());
+      // randomly choose a proxy thread to connect
+      int tid = 1 + rand() % PROXY_THREAD_NUM;
+      zmq_util::send_string(serialized_req, &requesters[proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_]);
+      string serialized_resp = zmq_util::recv_string(&requesters[proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_]);
+
+      communication::Response resp;
+      resp.ParseFromString(serialized_resp);
+
+      for (int i = 0; i < resp.tuple_size(); i++) {
+        if (resp.tuple(i).succeed()) {
+          vector<string> tokens;
+          split(resp.tuple(i).key(), '_', tokens);
+          string key = tokens[0];
+          string node_ip = tokens[1];
+          size_t access = stoi(resp.tuple(i).value());
+          key_access_frequency[key][node_ip] = access;
+        }
+      }
+
+      hotness_start = std::chrono::system_clock::now();
+    }
+
+    storage_end = std::chrono::system_clock::now();
+
+    if (chrono::duration_cast<std::chrono::seconds>(storage_end-storage_start).count() >= STORAGE_CONSUMPTION_REPORT_THRESHOLD) {
+      // fetch storage consumption data from the storage tier
+      communication::Request req;
+      req.set_type("GET");
+      req.set_metadata(true);
+
+      for (auto it = global_memory_hash_ring.begin(); it != global_memory_hash_ring.end(); it++) {
+        communication::Request_Tuple* tp = req.add_tuple();
+        tp->set_key(it->second.ip_ + "_storage");
+      }
+
+      for (auto it = global_ebs_hash_ring.begin(); it != global_ebs_hash_ring.end(); it++) {
+        for (int tid = 1; tid <= EBS_THREAD_NUM; tid++) {
+          communication::Request_Tuple* tp = req.add_tuple();
+          tp->set_key(it->second.ip_ + "_" + to_string(tid) + "_storage");
+        }
+      }
+
+      string serialized_req;
+      req.SerializeToString(&serialized_req);
+      // send the storage consumption update to a random proxy worker
+      // just pick the first proxy to contact for now;
+      // this should eventually be round-robin / random
+      string proxy_ip = *(proxy_address.begin());
+      // randomly choose a proxy thread to connect
+      int tid = 1 + rand() % PROXY_THREAD_NUM;
+      zmq_util::send_string(serialized_req, &requesters[proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_]);
+      string serialized_resp = zmq_util::recv_string(&requesters[proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_]);
+
+      communication::Response resp;
+      resp.ParseFromString(serialized_resp);
+
+      for (int i = 0; i < resp.tuple_size(); i++) {
+        if (resp.tuple(i).succeed()) {
+          vector<string> tokens;
+          split(resp.tuple(i).key(), '_', tokens);
+          string ip = tokens[0];
+
+          if (tokens.size() == 2) {
+            // memory
+            memory_tier_storage[tokens[0]] = stoi(resp.tuple(i).value());
+          } else if (tokens.size() == 3) {
+            // ebs
+            ebs_tier_storage[tokens[0]][tokens[1]] = stoi(resp.tuple(i).value());
+          }
+        }
+      }
+
+      size_t total_memory_consumption = 0;
+      size_t total_ebs_consumption = 0;
+      int memory_node_count = 0;
+      int ebs_volume_count = 0;
+
+      for (auto it = memory_tier_storage.begin(); it != memory_tier_storage.end(); it++) {
+        total_memory_consumption += it->second;
+        memory_node_count += 1;
+      }
+
+      for (auto it1 = ebs_tier_storage.begin(); it1 != ebs_tier_storage.end(); it1++) {
+        for (auto it2 = it1->second.begin(); it2 != it1->second.end(); it2++) {
+          total_ebs_consumption += it2->second;
+          ebs_volume_count += 1;
+        }
+      }
+
+      if ((double)total_memory_consumption / (double)memory_node_count > 0) {
+        cerr << "trigger add memory node\n";
+        string shell_command = "curl -X POST https://" + management_address + "/memory";
+        system(shell_command.c_str());
+      }
+
+      if ((double)total_ebs_consumption / (double)ebs_volume_count > 0) {
+        cerr << "trigger add ebs node\n";
+        string shell_command = "curl -X POST https://" + management_address + "/ebs";
+        system(shell_command.c_str());
+      }
+
+      storage_start = std::chrono::system_clock::now();
+    }
+
+    /*if (pollitems[2].revents & ZMQ_POLLIN) {
       cerr << "received storage update\n";
       string storage_msg = zmq_util::recv_string(&storage_consumption_puller);
       communication::Storage_Update su;
       su.ParseFromString(storage_msg);
       if (su.node_type() == "M") {
         memory_tier_storage[master_node_t(su.node_ip(), "M")] = su.memory_storage();
-        memory_tier_occupancy[master_node_t(su.node_ip(), "M")] = su.thread_occupancy();
       } else {
         ebs_tier_storage[master_node_t(su.node_ip(), "E")].clear();
 
@@ -304,7 +426,9 @@ int main(int argc, char* argv[]) {
         size_t access = khu.tuple(i).access();
         key_access_frequency[key][node_ip] = access;
       }
-    }
+    }*/
+
+
 
     // TODO: Add policy that triggers node join/removal and key replication factor change
 

--- a/kv_store/lww_kvs/kvs_monitoring.cpp
+++ b/kv_store/lww_kvs/kvs_monitoring.cpp
@@ -153,12 +153,12 @@ int main(int argc, char* argv[]) {
   address.close();
 
   // read address of management node from conf file
-  address_t management_address;
+  /*address_t management_address;
 
   address.open("conf/monitoring/management_ip.txt");
   getline(address, ip_line);
   management_address = ip_line;
-  address.close();
+  address.close();*/
 
 
   zmq::context_t context(1);
@@ -336,7 +336,7 @@ int main(int argc, char* argv[]) {
         }
       }
 
-      size_t total_memory_consumption = 0;
+      /*size_t total_memory_consumption = 0;
       size_t total_ebs_consumption = 0;
       int memory_node_count = 0;
       int ebs_volume_count = 0;
@@ -363,72 +363,10 @@ int main(int argc, char* argv[]) {
         cerr << "trigger add ebs node\n";
         string shell_command = "curl -X POST https://" + management_address + "/ebs";
         system(shell_command.c_str());
-      }
+      }*/
 
       storage_start = std::chrono::system_clock::now();
     }
-
-    /*if (pollitems[2].revents & ZMQ_POLLIN) {
-      cerr << "received storage update\n";
-      string storage_msg = zmq_util::recv_string(&storage_consumption_puller);
-      communication::Storage_Update su;
-      su.ParseFromString(storage_msg);
-      if (su.node_type() == "M") {
-        memory_tier_storage[master_node_t(su.node_ip(), "M")] = su.memory_storage();
-      } else {
-        ebs_tier_storage[master_node_t(su.node_ip(), "E")].clear();
-
-        for (int i = 0; i < su.ebs_size(); i++) {
-          ebs_tier_storage[master_node_t(su.node_ip(), "E")][su.ebs(i).id()] = su.ebs(i).storage();
-        }
-      }
-
-      size_t total_memory_consumption = 0;
-      size_t total_ebs_consumption = 0;
-      int memory_node_count = 0;
-      int ebs_volume_count = 0;
-
-      for (auto it = memory_tier_storage.begin(); it != memory_tier_storage.end(); it++) {
-        total_memory_consumption += it->second;
-        memory_node_count += 1;
-      }
-
-      for (auto it1 = ebs_tier_storage.begin(); it1 != ebs_tier_storage.end(); it1++) {
-        for (auto it2 = it1->second.begin(); it2 != it1->second.end(); it2++) {
-          total_ebs_consumption += it2->second;
-          ebs_volume_count += 1;
-        }
-      }
-
-      if ((double)total_memory_consumption / (double)memory_node_count > 0) {
-        cerr << "trigger add memory node\n";
-        string shell_command = "curl -X POST https://" + management_address + "/memory";
-        system(shell_command.c_str());
-      }
-
-      if ((double)total_ebs_consumption / (double)ebs_volume_count > 0) {
-        cerr << "trigger add ebs node\n";
-        string shell_command = "curl -X POST https://" + management_address + "/ebs";
-        system(shell_command.c_str());
-      }
-    }
-
-    if (pollitems[3].revents & ZMQ_POLLIN) {
-      cerr << "received key hotness update\n";
-      string hotness_msg = zmq_util::recv_string(&key_hotness_puller);
-      communication::Key_Hotness_Update khu;
-      khu.ParseFromString(hotness_msg);
-
-      string node_ip = khu.node_ip();
-
-      for (int i = 0; i < khu.tuple_size(); i++) {
-        string key = khu.tuple(i).key();
-        size_t access = khu.tuple(i).access();
-        key_access_frequency[key][node_ip] = access;
-      }
-    }*/
-
-
 
     // TODO: Add policy that triggers node join/removal and key replication factor change
 

--- a/kv_store/lww_kvs/kvs_proxy.cpp
+++ b/kv_store/lww_kvs/kvs_proxy.cpp
@@ -18,9 +18,6 @@
 #include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
 
-#define MONITORING_THRESHOLD 30
-#define MONITORING_PERIOD 10
-
 using namespace std;
 using address_t = string;
 using address_cache_t = unordered_map<address_t, unordered_map<string, unordered_set<address_t>>>;
@@ -35,10 +32,8 @@ struct key_access_info {
 };
 
 // given a key, check memory and ebs hash ring to find all the server nodes responsible for the key
-vector<master_node_t> get_nodes(string key, global_hash_t* global_memory_hash_ring, global_hash_t* global_ebs_hash_ring, tbb::concurrent_unordered_map<string, shared_key_info>* placement) {
+vector<master_node_t> get_nodes(string key, global_hash_t* global_memory_hash_ring, global_hash_t* global_ebs_hash_ring, int gmr, int ger) {
 
-  int gmr = placement->find(key)->second.global_memory_replication_.load();
-  int ger = placement->find(key)->second.global_ebs_replication_.load();
   vector<master_node_t> server_nodes;
   // use hash ring to find the right node to contact
   // first, look up the memory hash ring
@@ -96,7 +91,7 @@ void process_benchmark_request(string type,
                        std::forward_as_tuple(1, 0));
   }
 
-  vector<master_node_t> server_nodes = get_nodes(key, global_memory_hash_ring, global_ebs_hash_ring, placement);
+  vector<master_node_t> server_nodes = get_nodes(key, global_memory_hash_ring, global_ebs_hash_ring, placement->find(key)->second.global_memory_replication_.load(), placement->find(key)->second.global_ebs_replication_.load());
   // get a random node
   master_node_t server_node = server_nodes[rand() % server_nodes.size()];
 
@@ -132,23 +127,27 @@ void process_benchmark_request(string type,
   address_t worker_address = *(next(begin((*address_cache)[server_node.ip_][key]), rand() % (*address_cache)[server_node.ip_][key].size()));
 
   communication::Request req;
-
   if (type == "G") {
-    communication::Request_Get* g = req.add_get();
-    g->set_key(key);
+    req.set_type("GET");
   } else {
-    communication::Request_Put* p = req.add_put();
-    p->set_key(key);
-    p->set_value(value);
+    req.set_type("PUT");
+  }
+  req.set_metadata(false);
+
+  communication::Request_Tuple* tp = req.add_tuple();
+  tp->set_key(key);
+
+  if (type == "P") {
+    tp->set_value(value);
   }
 
-  string req_data;
-  req.SerializeToString(&req_data);
-  zmq_util::send_string(req_data, &requesters[worker_address]);
+  string serialized_req;
+  req.SerializeToString(&serialized_req);
+  zmq_util::send_string(serialized_req, &requesters[worker_address]);
 
   auto send_time = std::chrono::system_clock::now();
   // wait for response to actual request
-  req_data = zmq_util::recv_string(&requesters[worker_address]);
+  string serialized_resp = zmq_util::recv_string(&requesters[worker_address]);
   auto receive_time = std::chrono::system_clock::now();
 
   //cout << "request took " + to_string(chrono::duration_cast<std::chrono::microseconds>(receive_time-send_time).count()) + " microseconds\n";
@@ -172,8 +171,8 @@ void proxy_worker_routine(zmq::context_t* context,
   unordered_map<string, multiset<std::chrono::time_point<std::chrono::system_clock>>> key_access_monitoring;
 
   // responsible for receiving user requests
-  zmq::socket_t user_responder(*context, ZMQ_REP);
-  user_responder.bind(proxy_thread.user_request_bind_addr_);
+  zmq::socket_t request_responder(*context, ZMQ_REP);
+  request_responder.bind(proxy_thread.request_bind_addr_);
   // responsible for routing gossip to other tiers
   zmq::socket_t gossip_responder(*context, ZMQ_REP);
   gossip_responder.bind(proxy_thread.proxy_gossip_bind_addr_);
@@ -185,9 +184,9 @@ void proxy_worker_routine(zmq::context_t* context,
   SocketCache pushers(context, ZMQ_PUSH);
 
   vector<zmq::pollitem_t> pollitems = {
-    { static_cast<void *>(user_responder), 0, ZMQ_POLLIN, 0 },
+    { static_cast<void *>(request_responder), 0, ZMQ_POLLIN, 0 },
     { static_cast<void *>(gossip_responder), 0, ZMQ_POLLIN, 0 },
-    { static_cast<void *>(benchmark_puller), 0, ZMQ_POLLIN, 0 },
+    { static_cast<void *>(benchmark_puller), 0, ZMQ_POLLIN, 0 }
   };
 
   auto hotness_start = std::chrono::system_clock::now();
@@ -200,175 +199,163 @@ void proxy_worker_routine(zmq::context_t* context,
     zmq_util::poll(0, &pollitems);
 
     if (pollitems[0].revents & ZMQ_POLLIN) {
-      // handle a user facing request
-      cerr << "received user request\n";
-      vector<string> v; 
+      // handle a request
+      cerr << "received request\n";
 
-      // NOTE: once we start thinking about building a programmatic API, we
-      // will need a more robust form of serialization between the user & the
-      // proxy & the server
-      split(zmq_util::recv_string(&user_responder), ' ', v);
+      string data = zmq_util::recv_string(&request_responder);
+      communication::Request req;
+      req.ParseFromString(data);
 
-      if (v.size() == 0) {
-          zmq_util::send_string("Empty request.\n", &user_responder);
-      } else if (v[0] != "GET" && v[0] != "PUT") { 
-          zmq_util::send_string("Invalid request: " + v[0] + ".\n", &user_responder);
-      } else {
-        bool proceed = true;
-        // this data structure is for keeping track of the key value mapping in PUT request
-        unordered_map<string, string> key_value_map;
-        unordered_map<address_t, communication::Request> request_map;
-        unordered_map<master_node_t, communication::Key_Request, node_hash> key_request_map;
-        vector<string> queries;
-        split(v[1], ',', queries);
-        for (auto it = queries.begin(); it != queries.end(); it++) {
-          string key;
-          if (v[0] == "GET") {
-            key = *it;
-          } else {
-            vector<string> kv_pair;
-            split(*it, ':', kv_pair);
-            key = kv_pair[0];
-            // update key_value map for later value tracking
-            key_value_map[key] = kv_pair[1];
-          }
-          // if the replication factor info is missing, query the monitoring node
-          if (placement->find(key) == placement->end()) {
-            zmq_util::send_string(key, &requesters[monitoring_node.replication_factor_connect_addr_]);
+      // this data structure is for keeping track of the key value mapping in PUT request
+      unordered_map<string, string> key_value_map;
+      unordered_map<address_t, communication::Request> request_map;
+      unordered_map<master_node_t, communication::Key_Request, node_hash> key_request_map;
 
-            string replication_factor_response = zmq_util::recv_string(&requesters[monitoring_node.replication_factor_connect_addr_]);
-            communication::Replication_Factor replication_factor;
-            replication_factor.ParseFromString(replication_factor_response);
+      for (int i = 0; i < req.tuple_size(); i++) {
+        string key = req.tuple(i).key();
 
-            placement->emplace(std::piecewise_construct,
-                               std::forward_as_tuple(key),
-                               std::forward_as_tuple(replication_factor.global_memory_replication(), replication_factor.global_ebs_replication()));
-          }
+        if (req.type() == "PUT") {
+          key_value_map[key] = req.tuple(i).value();
+        }
 
+        // if the replication factor info is missing, query the monitoring node
+        if (!req.metadata() && placement->find(key) == placement->end()) {
+          zmq_util::send_string(key, &requesters[monitoring_node.replication_factor_connect_addr_]);
+
+          string replication_factor_response = zmq_util::recv_string(&requesters[monitoring_node.replication_factor_connect_addr_]);
+          communication::Replication_Factor replication_factor;
+          replication_factor.ParseFromString(replication_factor_response);
+
+          placement->emplace(std::piecewise_construct,
+                             std::forward_as_tuple(key),
+                             std::forward_as_tuple(replication_factor.global_memory_replication(), replication_factor.global_ebs_replication()));
+        }
+
+        int gmr;
+        int ger;
+
+        if (!req.metadata()) {
           // update key access monitoring map
           key_access_monitoring[key].insert(std::chrono::system_clock::now());
-
-          vector<master_node_t> server_nodes = get_nodes(key, global_memory_hash_ring, global_ebs_hash_ring, placement);
-          if (server_nodes.size() != 0) {
-            // get a random node
-            master_node_t server_node = server_nodes[rand() % server_nodes.size()];
-
-            if (address_cache->find(server_node.ip_) == address_cache->end() || address_cache->at(server_node.ip_).find(key) == address_cache->at(server_node.ip_).end()) {
-              // TODO: before setting the sender, check if it's already been set
-              key_request_map[server_node].set_sender("proxy");
-              communication::Key_Request_Tuple* tp = key_request_map[server_node].add_tuple();
-              tp->set_key(key);
-              tp->set_global_memory_replication(placement->find(key)->second.global_memory_replication_.load());
-              tp->set_global_ebs_replication(placement->find(key)->second.global_ebs_replication_.load());
-            } else {
-              address_t worker_address = *(next(begin((*address_cache)[server_node.ip_][key]), rand() % (*address_cache)[server_node.ip_][key].size()));
-
-              if (v[0] == "GET") {
-                communication::Request_Get* g = request_map[worker_address].add_get();
-                g->set_key(key);
-              } else {
-                communication::Request_Put* p = request_map[worker_address].add_put();
-                p->set_key(key);
-                p->set_value(key_value_map[key]);
-              }
-            }
-          } else {
-            zmq_util::send_string("No servers available.\n", &user_responder);
-            proceed = false;
-            break;
-          }
+          gmr = placement->find(key)->second.global_memory_replication_.load();
+          ger = placement->find(key)->second.global_ebs_replication_.load();
+        } else {
+          gmr = METADATA_REPLICATION_FACTOR;
+          ger = 0;
         }
 
-        if (proceed) {
-          // loop through key request map, send key request to all nodes
-          // receive key responses, and form the request map
-          for (auto it = key_request_map.begin(); it != key_request_map.end(); it++) {
-            // serialize request and send
-            string key_req;
-            it->second.SerializeToString(&key_req);
-            zmq_util::send_string(key_req, &requesters[it->first.key_exchange_connect_addr_]);
+        vector<master_node_t> server_nodes = get_nodes(key, global_memory_hash_ring, global_ebs_hash_ring, gmr, ger);
 
-            auto send_time = std::chrono::system_clock::now();
-            // wait for a response from the server and deserialize
-            string key_res = zmq_util::recv_string(&requesters[it->first.key_exchange_connect_addr_]);
-            auto receive_time = std::chrono::system_clock::now();
+        if (server_nodes.size() != 0) {
+          // get a random node
+          master_node_t server_node = server_nodes[rand() % server_nodes.size()];
 
-            cout << "key request took " + to_string(chrono::duration_cast<std::chrono::microseconds>(receive_time-send_time).count()) + " microseconds\n";
-
-            communication::Key_Response server_res;
-            server_res.ParseFromString(key_res);
-
-            string key;
-            address_t worker_address;
-            // get the worker address from the response and sent the serialized
-            // data from up above to the worker thread; the reason that we do
-            // this is to let the metadata thread avoid having to receive a
-            // potentially large request body; since the metadata thread is
-            // serial, this could potentially be a bottleneck; the current way
-            // allows the metadata thread to answer lightweight requests only
-            for (int i = 0; i < server_res.tuple_size(); i++) {
-              key = server_res.tuple(i).key();
-
-              // update address cache
-              for (int j = 0; j < server_res.tuple(i).address_size(); j++) {
-                (*address_cache)[it->first.ip_][key].insert(server_res.tuple(i).address(j).addr());
-              }
-              /*if (it->first.tier_ == "E") {
-                // randomly choose a worker address for a key
-                worker_address = server_res.tuple(i).address(rand() % server_res.tuple(i).address().size()).addr();
-              } else {
-                // we only have one address for memory tier
-                worker_address = server_res.tuple(i).address(0).addr();
-              }*/
-              worker_address = *(next(begin((*address_cache)[it->first.ip_][key]), rand() % (*address_cache)[it->first.ip_][key].size()));
-
-              cout << "worker address is " + worker_address + "\n";
-
-              if (v[0] == "GET") {
-                communication::Request_Get* g = request_map[worker_address].add_get();
-                g->set_key(key);
-              } else {
-                communication::Request_Put* p = request_map[worker_address].add_put();
-                p->set_key(key);
-                p->set_value(key_value_map[key]);
-              }
+          if (address_cache->find(server_node.ip_) == address_cache->end() || address_cache->at(server_node.ip_).find(key) == address_cache->at(server_node.ip_).end()) {
+            // TODO: before setting the sender, check if it's already been set
+            key_request_map[server_node].set_sender("proxy");
+            communication::Key_Request_Tuple* tp = key_request_map[server_node].add_tuple();
+            tp->set_key(key);
+            tp->set_global_memory_replication(METADATA_REPLICATION_FACTOR);
+            tp->set_global_ebs_replication(0);
+          } else {
+            address_t worker_address = *(next(begin((*address_cache)[server_node.ip_][key]), rand() % (*address_cache)[server_node.ip_][key].size()));
+            request_map[worker_address].set_type(req.type());
+            communication::Request_Tuple* tp = request_map[worker_address].add_tuple();
+            if (req.type() == "GET") {
+              tp->set_key(key);
+            } else {
+              tp->set_key(key);
+              tp->set_value(key_value_map[key]);
             }
           }
-
-          // initialize the respond string
-          string response_string = "";
-          for (auto it = request_map.begin(); it != request_map.end(); it++) {
-            string data;
-            it->second.SerializeToString(&data);
-            zmq_util::send_string(data, &requesters[it->first]);
-
-            auto send_time = std::chrono::system_clock::now();
-            // wait for response to actual request
-            data = zmq_util::recv_string(&requesters[it->first]);
-            auto receive_time = std::chrono::system_clock::now();
-
-            cout << "request took " + to_string(chrono::duration_cast<std::chrono::microseconds>(receive_time-send_time).count()) + " microseconds\n";
-
-            communication::Response response;
-            response.ParseFromString(data);
-
-            for (int i = 0; i < response.tuple_size(); i++) {
-              // TODO: send a more intelligent response to the user based on the response from server
-              // TODO: we should send a protobuf response that is deserialized on the proxy side... allows for a programmatic API
-              if (v[0] == "GET") {
-                if (response.tuple(i).succeed()) {
-                  response_string += ("value of key " + response.tuple(i).key() + " is " + response.tuple(i).value() + ".\n");
-                } else {
-                  response_string += ("key " + response.tuple(i).key() + " does not exist\n");
-                }
-              } else {
-                response_string += ("succeed status is " + to_string(response.tuple(i).succeed()) + " for key " + response.tuple(i).key() + "\n");
-              }
-            }
-          }
-          zmq_util::send_string(response_string, &user_responder);
+        } else {
+          cerr << "ERROR: No servers available.\n";
+          break;
         }
       }
+
+      // loop through key request map, send key request to all nodes
+      // receive key responses, and form the request map
+      for (auto it = key_request_map.begin(); it != key_request_map.end(); it++) {
+        // serialize request and send
+        string key_req;
+        it->second.SerializeToString(&key_req);
+        zmq_util::send_string(key_req, &requesters[it->first.key_exchange_connect_addr_]);
+
+        auto send_time = std::chrono::system_clock::now();
+        // wait for a response from the server and deserialize
+        string key_res = zmq_util::recv_string(&requesters[it->first.key_exchange_connect_addr_]);
+        auto receive_time = std::chrono::system_clock::now();
+
+        cout << "key request took " + to_string(chrono::duration_cast<std::chrono::microseconds>(receive_time-send_time).count()) + " microseconds\n";
+
+        communication::Key_Response server_res;
+        server_res.ParseFromString(key_res);
+
+        string key;
+        address_t worker_address;
+        // get the worker address from the response and sent the serialized
+        // data from up above to the worker thread; the reason that we do
+        // this is to let the metadata thread avoid having to receive a
+        // potentially large request body; since the metadata thread is
+        // serial, this could potentially be a bottleneck; the current way
+        // allows the metadata thread to answer lightweight requests only
+        for (int i = 0; i < server_res.tuple_size(); i++) {
+          key = server_res.tuple(i).key();
+
+          // update address cache
+          for (int j = 0; j < server_res.tuple(i).address_size(); j++) {
+            (*address_cache)[it->first.ip_][key].insert(server_res.tuple(i).address(j).addr());
+          }
+
+          worker_address = *(next(begin((*address_cache)[it->first.ip_][key]), rand() % (*address_cache)[it->first.ip_][key].size()));
+
+          cout << "worker address is " + worker_address + "\n";
+
+          request_map[worker_address].set_type(req.type());
+          communication::Request_Tuple* tp = request_map[worker_address].add_tuple();
+
+          if (req.type() == "GET") {
+            tp->set_key(key);
+          } else {
+            tp->set_key(key);
+            tp->set_value(key_value_map[key]);
+          }
+        }
+      }
+
+      // initialize the respond message
+      communication::Response resp;
+      resp.set_type(req.type());
+
+      for (auto it = request_map.begin(); it != request_map.end(); it++) {
+        string data;
+        it->second.SerializeToString(&data);
+        zmq_util::send_string(data, &requesters[it->first]);
+
+        auto send_time = std::chrono::system_clock::now();
+        // wait for response to actual request
+        data = zmq_util::recv_string(&requesters[it->first]);
+        auto receive_time = std::chrono::system_clock::now();
+
+        cout << "request took " + to_string(chrono::duration_cast<std::chrono::microseconds>(receive_time-send_time).count()) + " microseconds\n";
+
+        communication::Response response;
+        response.ParseFromString(data);
+
+        for (int i = 0; i < response.tuple_size(); i++) {
+          communication::Response_Tuple* tp = resp.add_tuple();
+          tp->set_succeed(response.tuple(i).succeed());
+          tp->set_key(response.tuple(i).key());
+          if (req.type() == "GET") {
+            tp->set_value(response.tuple(i).value());
+          }
+        }
+      }
+
+      string serialized_resp;
+      resp.SerializeToString(&serialized_resp);
+      zmq_util::send_string(serialized_resp, &request_responder);
     }
 
     if (pollitems[1].revents & ZMQ_POLLIN) {
@@ -389,9 +376,9 @@ void proxy_worker_routine(zmq::context_t* context,
       for (int i = 0; i < req.tuple_size(); i++) {
         string key = req.tuple(i).key();
         if (target_tier == "M") {
-          server_nodes = get_nodes(key, global_memory_hash_ring, nullptr, placement);
+          server_nodes = get_nodes(key, global_memory_hash_ring, nullptr, placement->find(key)->second.global_memory_replication_.load(), placement->find(key)->second.global_ebs_replication_.load());
         } else {
-          server_nodes = get_nodes(key, nullptr, global_ebs_hash_ring, placement);
+          server_nodes = get_nodes(key, nullptr, global_ebs_hash_ring, placement->find(key)->second.global_memory_replication_.load(), placement->find(key)->second.global_ebs_replication_.load());
         }
 
         if (server_nodes.size() == 0) {
@@ -526,7 +513,7 @@ void proxy_worker_routine(zmq::context_t* context,
 
     hotness_end = std::chrono::system_clock::now();
 
-    if (chrono::duration_cast<std::chrono::seconds>(hotness_end-hotness_start).count() >= MONITORING_PERIOD) {
+    if (chrono::duration_cast<std::chrono::seconds>(hotness_end-hotness_start).count() >= HOTNESS_MONITORING_PERIOD) {
       timestamp++;
 
       for (auto map_iter = key_access_monitoring.begin(); map_iter != key_access_monitoring.end(); map_iter++) {
@@ -535,7 +522,7 @@ void proxy_worker_routine(zmq::context_t* context,
 
         // garbage collect key_access_monitoring
         for (auto set_iter = mset.rbegin(); set_iter != mset.rend(); set_iter++) {
-          if (chrono::duration_cast<std::chrono::seconds>(hotness_end-*set_iter).count() >= MONITORING_THRESHOLD) {
+          if (chrono::duration_cast<std::chrono::seconds>(hotness_end-*set_iter).count() >= HOTNESS_MONITORING_THRESHOLD) {
             mset.erase(mset.begin(), set_iter.base());
             break;
           }
@@ -615,7 +602,13 @@ int main(int argc, char* argv[]) {
 
   zmq::context_t context(1);
 
+  SocketCache requesters(&context, ZMQ_REQ);
   SocketCache pushers(&context, ZMQ_PUSH);
+
+  // notify monitoring nodes
+  for (auto it = monitoring_address.begin(); it != monitoring_address.end(); it++) {
+    zmq_util::send_string("join:P:" + ip, &pushers[monitoring_node_t(*it).notify_connect_addr_]);
+  }
 
   vector<thread> proxy_worker_threads;
 
@@ -728,17 +721,23 @@ int main(int argc, char* argv[]) {
       for (auto it = proxy_thread_report.begin(); it != proxy_thread_report.end(); it++) {
         if (it->second.size() == PROXY_THREAD_NUM) {
           ts_to_remove.insert(it->first);
-          // send hotness info to the monitoring node
-          communication::Key_Hotness_Update khu;
-          khu.set_node_ip(ip);
+          // send hotness info to the storage tier
+          communication::Request req;
+          req.set_type("PUT");
+          req.set_metadata(true);
+
           for (auto iter = timestamp_key_access_frequency[it->first].begin(); iter != timestamp_key_access_frequency[it->first].end(); iter++) {
-            communication::Key_Hotness_Update_Tuple* tp = khu.add_tuple();
-            tp->set_key(iter->first);
-            tp->set_access(iter->second);
+            communication::Request_Tuple* tp = req.add_tuple();
+            tp->set_key(iter->first + "_" + ip + "_hotness");
+            tp->set_value(to_string(iter->second));
           }
-          string msg;
-          khu.SerializeToString(&msg);
-          zmq_util::send_string(msg, &pushers[monitoring_node.key_hotness_connect_addr_]);
+          string serialized_req;
+          req.SerializeToString(&serialized_req);
+
+          // randomly choose a local proxy worker thread to connect
+          int tid = 1 + rand() % PROXY_THREAD_NUM;
+          zmq_util::send_string(serialized_req, &requesters[proxy_worker_thread_t(ip, tid).request_connect_addr_]);
+          zmq_util::recv_string(&requesters[proxy_worker_thread_t(ip, tid).request_connect_addr_]);
         }
       }
 

--- a/kv_store/lww_kvs/kvs_user.cpp
+++ b/kv_store/lww_kvs/kvs_user.cpp
@@ -8,11 +8,67 @@
 #include <unistd.h>
 #include <memory>
 #include <unordered_set>
+#include "message.pb.h"
 #include "socket_cache.h"
 #include "zmq_util.h"
 #include "common.h"
 
 using namespace std;
+
+string handle_request(string input, zmq::socket_t& proxy_connector) {
+  vector<string> v;
+  split(input, ' ', v);
+
+  if (v.size() == 0) {
+    return "Empty request.\n";
+  } else if (v[0] != "GET" && v[0] != "PUT") { 
+    return "Invalid request: " + v[0] + ".\n";
+  } else {
+    communication::Request req;
+    req.set_type(v[0]);
+    req.set_metadata(false);
+
+    vector<string> queries;
+    split(v[1], ',', queries);
+    for (auto it = queries.begin(); it != queries.end(); it++) {
+      communication::Request_Tuple* tp = req.add_tuple();
+      if (v[0] == "GET") {
+        tp->set_key(*it);
+      } else {
+        vector<string> kv_pair;
+        split(*it, ':', kv_pair);
+        tp->set_key(kv_pair[0]);
+        tp->set_value(kv_pair[1]);
+      }
+    }
+
+    string serialized_req;
+    req.SerializeToString(&serialized_req);
+    zmq_util::send_string(serialized_req, &proxy_connector);
+
+    string serialized_resp = zmq_util::recv_string(&proxy_connector);
+    communication::Response resp;
+    resp.ParseFromString(serialized_resp);
+
+    // initialize the respond string
+    string response_string = "";
+    for (int i = 0; i < resp.tuple_size(); i++) {
+      // TODO: send a more intelligent response to the user based on the response from server
+      // TODO: we should send a protobuf response that is deserialized on the proxy side... allows for a programmatic API
+      if (v[0] == "GET") {
+        if (resp.tuple(i).succeed()) {
+          response_string += ("value of key " + resp.tuple(i).key() + " is " + resp.tuple(i).value() + ".\n");
+        } else {
+          response_string += ("key " + resp.tuple(i).key() + " does not exist\n");
+        }
+      } else {
+        response_string += ("succeed status is " + to_string(resp.tuple(i).succeed()) + " for key " + resp.tuple(i).key() + "\n");
+      }
+    }
+
+    return response_string;
+  }
+}
 
 int main(int argc, char* argv[]) {
 
@@ -46,7 +102,7 @@ int main(int argc, char* argv[]) {
   string proxy_ip = *(proxy_address.begin());
   // randomly choose a proxy thread to connect
   int tid = 1 + rand() % PROXY_THREAD_NUM;
-  string target_proxy_address = proxy_worker_thread_t(proxy_ip, tid).user_request_connect_addr_;
+  string target_proxy_address = proxy_worker_thread_t(proxy_ip, tid).request_connect_addr_;
   proxy_connector.connect(target_proxy_address);
 
   if (!batch) {
@@ -55,8 +111,7 @@ int main(int argc, char* argv[]) {
     while (true) {
       cout << "kvs> ";
       getline(cin, input);
-      zmq_util::send_string(input, &proxy_connector);
-      cout << zmq_util::recv_string(&proxy_connector);
+      cout << handle_request(input, proxy_connector);
     }
   } else {
     // read in the request
@@ -65,8 +120,7 @@ int main(int argc, char* argv[]) {
     request_reader.open(argv[1]);
 
     while (getline(request_reader, request)) {
-      zmq_util::send_string(request, &proxy_connector);
-      cout << zmq_util::recv_string(&proxy_connector);
+      cout << handle_request(request, proxy_connector);
     }
   }
 }

--- a/kv_store/lww_kvs/message.proto
+++ b/kv_store/lww_kvs/message.proto
@@ -2,18 +2,14 @@ package communication;
 
 message Request {
 
-  message Get {
+  message Tuple {
     required string key = 1;
-  }
-
-  message Put {
-    required string key = 1;
-    required string value = 2;
+    optional string value = 2;
     optional int64 timestamp = 3;
   }
-
-  repeated Get get = 1;
-  repeated Put put = 2;
+  required string type = 1;
+  optional bool metadata = 2;
+  repeated Tuple tuple = 3;
 }
 
 
@@ -24,8 +20,8 @@ message Response {
     optional string value = 3;
     optional int64 timestamp = 4;
   }
-
-  repeated Tuple tuple = 1;
+  required string type = 1;
+  repeated Tuple tuple = 2;
 }
 
 
@@ -88,8 +84,7 @@ message Storage_Update {
   required string node_ip = 1;
   required string node_type = 2;
   optional int64 memory_storage = 3;
-  optional float thread_occupancy = 4;
-  repeated EBS ebs = 5;
+  repeated EBS ebs = 4;
 }
 
 message Key_Hotness_Update {


### PR DESCRIPTION
storage tier sends the storage consumption metadata as PUT request to the proxy worker through `metadata_puller`.
proxy metadata thread sends key hotness metadata as PUT request to the proxy worker through `metadata_puller`.