### PR TITLE
Unified storage architecture

### DIFF
--- a/k8s/start.sh
+++ b/k8s/start.sh
@@ -36,7 +36,7 @@ else
   if [ "$1" = "m" ]; then
     ./build/kv_store/lww_kvs/kvs_memory_server $NEW
   elif [ "$1" = "e" ]; then
-    ./build/kv_store/lww_kvs/kvs_ebs_server $NEW n
+    ./build/kv_store/lww_kvs/kvs_ebs_server $NEW
   else
     echo "Unrecognized server type: $1. Exiting."
     exit 1

--- a/kv_store/include/base_kv_store.h
+++ b/kv_store/include/base_kv_store.h
@@ -9,111 +9,100 @@ using namespace std;
 template <typename K, typename V>
 class KV_Store{
 protected:
-	MapLattice<K, V> db;
+  MapLattice<K, V> db;
 public:
-  // keep track of the size of values
-  unordered_map<K, size_t> size_map;
-
-	KV_Store<K, V>() {}
-	KV_Store<K, V>(MapLattice<K, V> &other) {
-		db = other;
-	}
-	V get(const K& k, bool& succeed) {
+  KV_Store<K, V>() {}
+  KV_Store<K, V>(MapLattice<K, V> &other) {
+    db = other;
+  }
+  V get(const K& k, bool& succeed) {
     if (db.contain(k).reveal()) {
       succeed = true;
     } else {
       succeed = false;
     }
-		return db.at(k);
-	}
-	void put(const K& k, const V &v, bool& succeed) {
-		bool replaced = db.at(k).Merge(v);
-    if (replaced) {
-      size_map[k] = v.reveal().value.length();
-    }
+    return db.at(k);
+  }
+  bool put(const K& k, const V &v, bool& succeed) {
+    bool replaced = db.at(k).Merge(v);
     succeed = true;
-	}
+    return replaced;
+  }
+  void remove(const K& k) {
+    db.remove(k);
+  }
 };
 
 // Lock-free implementation of concurrent kvs
 template <typename K, typename V>
 class Concurrent_KV_Store{
 protected:
-	AtomicMapLattice<K, V> db;
-	tbb::concurrent_unordered_map<K, atomic<int>*> lock_table;
+  AtomicMapLattice<K, V> db;
+  tbb::concurrent_unordered_map<K, atomic<int>*> lock_table;
 public:
-  // keep track of the size of values
-  tbb::concurrent_unordered_map<K, atomic<size_t>*> size_map;
-
-	Concurrent_KV_Store<K, V>() {}
-	Concurrent_KV_Store<K, V>(AtomicMapLattice<K, V> &other) {
-		db = other;
-	}
-	V get(const K& k, bool& succeed) {
-		auto it = lock_table.find(k);
-		if (it == lock_table.end()) {
-			it = lock_table.insert({k, new atomic<int>(0)}).first;
-		}
-		int expected = 0;
-		while(!it->second->compare_exchange_strong(expected, expected - 1)) {
-			if (expected > 0) expected = 0;
-		}
+  Concurrent_KV_Store<K, V>() {}
+  Concurrent_KV_Store<K, V>(AtomicMapLattice<K, V> &other) {
+    db = other;
+  }
+  V get(const K& k, bool& succeed) {
+    auto it = lock_table.find(k);
+    if (it == lock_table.end()) {
+      it = lock_table.insert({k, new atomic<int>(0)}).first;
+    }
+    int expected = 0;
+    while(!it->second->compare_exchange_strong(expected, expected - 1)) {
+      if (expected > 0) expected = 0;
+    }
     if (db.contain(k).reveal()) {
       succeed = true;
     } else {
       succeed = false;
     }
-		V result = db.at(k);
-		it->second->fetch_add(1);
-		return result;
-	}
-	void put(const K& k, const V& v, bool& succeed) {
-		auto it = lock_table.find(k);
-		if (it == lock_table.end()) {
-			it = lock_table.insert({k, new atomic<int>(0)}).first;
-		}
-		int expected = 0;
-		while(!it->second->compare_exchange_strong(expected, expected + 1)) {
-			expected = 0;
-		}
-		bool replaced = db.at(k).Merge(v);
-    if (replaced) {
-      if (size_map.find(k) == size_map.end()) {
-        size_map.insert({k, new atomic<size_t>(v.reveal().value.length())});
-      } else {
-        size_map[k]->store(v.reveal().value.length());
-      }
+    V result = db.at(k);
+    it->second->fetch_add(1);
+    return result;
+  }
+  bool put(const K& k, const V& v, bool& succeed) {
+    auto it = lock_table.find(k);
+    if (it == lock_table.end()) {
+      it = lock_table.insert({k, new atomic<int>(0)}).first;
     }
+    int expected = 0;
+    while(!it->second->compare_exchange_strong(expected, expected + 1)) {
+      expected = 0;
+    }
+    bool replaced = db.at(k).Merge(v);
     succeed = true;
-		it->second->fetch_sub(1);
-	}
+    it->second->fetch_sub(1);
+    return replaced;
+  }
 };
 
 // Concurrent kvs implementation using software lock (mutex). Not as efficient as the previous lock-free implementation.
 
 // class Concurrent_KV_Store{
 // protected:
-// 	AtomicMapLattice<int, KVS_PairLattice> db;
-// 	tbb::concurrent_unordered_map<int, unique_ptr<mutex>> lock_table;
+//  AtomicMapLattice<int, KVS_PairLattice> db;
+//  tbb::concurrent_unordered_map<int, unique_ptr<mutex>> lock_table;
 // public:
-// 	Concurrent_KV_Store() {}
-// 	Concurrent_KV_Store(AtomicMapLattice<int, KVS_PairLattice> other) {
-// 		db = other;
-// 	}
-// 	version_value_pair get(int k) {
-// 		auto it = lock_table.find(k);
-// 		if (it == lock_table.end()) {
-// 			it = lock_table.insert({k, unique_ptr<mutex>(new mutex)}).first;
-// 		}
-// 		lock_guard<mutex> lg(*(it->second));
-// 		return db.at(k).reveal();
-// 	}
-// 	void put(const int &k, const version_value_pair &p) {
-// 		auto it = lock_table.find(k);
-// 		if (it == lock_table.end()) {
-// 			it = lock_table.insert({k, unique_ptr<mutex>(new mutex)}).first;
-// 		}
-// 		lock_guard<mutex> lg(*(it->second));
-// 		db.at(k).merge(p);
-// 	}
+//  Concurrent_KV_Store() {}
+//  Concurrent_KV_Store(AtomicMapLattice<int, KVS_PairLattice> other) {
+//    db = other;
+//  }
+//  version_value_pair get(int k) {
+//    auto it = lock_table.find(k);
+//    if (it == lock_table.end()) {
+//      it = lock_table.insert({k, unique_ptr<mutex>(new mutex)}).first;
+//    }
+//    lock_guard<mutex> lg(*(it->second));
+//    return db.at(k).reveal();
+//  }
+//  void put(const int &k, const version_value_pair &p) {
+//    auto it = lock_table.find(k);
+//    if (it == lock_table.end()) {
+//      it = lock_table.insert({k, unique_ptr<mutex>(new mutex)}).first;
+//    }
+//    lock_guard<mutex> lg(*(it->second));
+//    db.at(k).merge(p);
+//  }
 // };

--- a/kv_store/include/common.h
+++ b/kv_store/include/common.h
@@ -20,8 +20,8 @@ using namespace std;
 #define METADATA_REPLICATION_FACTOR 1
 
 // Define the default replication factor for the data
-#define DEFAULT_GLOBAL_MEMORY_REPLICATION 1
-#define DEFAULT_GLOBAL_EBS_REPLICATION 0
+#define DEFAULT_GLOBAL_MEMORY_REPLICATION 2
+#define DEFAULT_GLOBAL_EBS_REPLICATION 1
 
 // Define the number of memory threads
 #define MEMORY_THREAD_NUM 1

--- a/kv_store/include/common.h
+++ b/kv_store/include/common.h
@@ -23,6 +23,9 @@ using namespace std;
 #define DEFAULT_GLOBAL_MEMORY_REPLICATION 1
 #define DEFAULT_GLOBAL_EBS_REPLICATION 0
 
+// Define the number of memory threads
+#define MEMORY_THREAD_NUM 1
+
 // Define the number of ebs threads
 #define EBS_THREAD_NUM 3
 
@@ -221,7 +224,7 @@ struct shared_key_info {
   atomic<int> global_ebs_replication_;
 };
 
-struct crc32_hasher {
+struct global_hasher {
   uint32_t operator()(const node_t& node) {
     boost::crc_32_type ret;
     ret.process_bytes(node.id_.c_str(), node.id_.size());
@@ -235,7 +238,7 @@ struct crc32_hasher {
   typedef uint32_t result_type;
 };
 
-struct ebs_hasher {
+struct local_hasher {
   hash<string>::result_type operator()(const node_t& node) {
     return hash<string>{}(node.id_);
   }
@@ -274,6 +277,6 @@ string get_ip(string node_type) {
   return server_ip;
 }
 
-typedef consistent_hash_map<master_node_t,crc32_hasher> global_hash_t;
+typedef consistent_hash_map<master_node_t,global_hasher> global_hash_t;
 
 #endif

--- a/kv_store/include/server_utility.h
+++ b/kv_store/include/server_utility.h
@@ -5,6 +5,9 @@
 
 using namespace std;
 
+// Define the default local replication factor
+#define DEFAULT_LOCAL_REPLICATION 1
+
 string alphabet("abcdefghijklmnopqrstuvwxyz");
 
 string getNextDeviceID(string currentID) {
@@ -19,6 +22,17 @@ string getNextDeviceID(string currentID) {
 			return "error: name out of bound\n";
 	}
 }
+
+struct storage_key_info {
+  storage_key_info() : global_memory_replication_(1), global_ebs_replication_(2), local_replication_(1) {}
+  storage_key_info(int gmr, int ger, int lr)
+    : global_memory_replication_(gmr), global_ebs_replication_(ger), local_replication_(lr) {}
+  storage_key_info(int gmr, int ger)
+    : global_memory_replication_(gmr), global_ebs_replication_(ger), local_replication_(DEFAULT_LOCAL_REPLICATION) {}
+  int global_memory_replication_;
+  int global_ebs_replication_;
+  int local_replication_;
+};
 
 struct pair_hash {
   template <class T1, class T2>
@@ -64,6 +78,7 @@ pair<bool, N*> responsible(string key, int rep, consistent_hash_map<N,H>& hash_r
   }
 }
 
+// contact target_node_address to get the worker address that's responsible for the keys
 template<typename T>
 communication::Key_Response get_key_address(string target_node_address, string target_tier, unordered_set<string> keys, SocketCache& requesters, unordered_map<string, T> placement) {
   // form key address request

--- a/kv_store/include/server_utility.h
+++ b/kv_store/include/server_utility.h
@@ -80,14 +80,14 @@ pair<bool, N*> responsible(string key, int rep, consistent_hash_map<N,H>& hash_r
 
 // contact target_node_address to get the worker address that's responsible for the keys
 template<typename T>
-communication::Key_Response get_key_address(string target_node_address, string target_tier, unordered_set<string> keys, SocketCache& requesters, unordered_map<string, T> placement) {
+communication::Key_Response get_key_address(string target_node_address, string source_tier, unordered_set<string> keys, SocketCache& requesters, unordered_map<string, T> placement) {
   // form key address request
   communication::Key_Request req;
   req.set_sender("server");
-  if (target_tier == "M") {
-    req.set_target_tier("M");
-  } else if (target_tier == "E") {
-    req.set_target_tier("E");
+  if (source_tier == "M") {
+    req.set_source_tier("M");
+  } else if (source_tier == "E") {
+    req.set_source_tier("E");
   }
   for (auto it = keys.begin(); it != keys.end(); it++) {
     communication::Key_Request_Tuple* tp = req.add_tuple();

--- a/kv_store/lww_kvs/kvs_ebs_server.cpp
+++ b/kv_store/lww_kvs/kvs_ebs_server.cpp
@@ -29,6 +29,9 @@ using namespace std;
 // Define the gossip period (frequency)
 #define PERIOD 10
 
+// Define node type
+#define NODE_TYPE "E"
+
 // Define the locatioon of the conf file with the ebs root path
 #define EBS_ROOT_FILE "conf/server/ebs_root.txt"
 
@@ -56,7 +59,6 @@ typedef unordered_map<string, unordered_set<pair<string, bool>, pair_hash>> redi
 // TODO:  this should be changed to something more globally robust
 atomic<int> lww_timestamp(0);
 
-bool enable_ebs(false);
 string ebs_root("empty");
 
 string get_ebs_path(string subpath) {
@@ -278,10 +280,6 @@ void worker_routine (zmq::context_t* context, string ip, int thread_id) {
   zmq::socket_t lredistribute_puller(*context, ZMQ_PULL);
   lredistribute_puller.bind(wnode.local_redistribute_addr_);
 
-  // socket that listens for departure command
-  zmq::socket_t depart_puller(*context, ZMQ_PULL);
-  depart_puller.bind(wnode.local_depart_addr_);
-
   // used to communicate with master thread for changeset addresses
   zmq::socket_t changeset_address_requester(*context, ZMQ_REQ);
   changeset_address_requester.connect(CHANGESET_ADDR);
@@ -294,8 +292,7 @@ void worker_routine (zmq::context_t* context, string ip, int thread_id) {
     { static_cast<void *>(responder), 0, ZMQ_POLLIN, 0 },
     { static_cast<void *>(dgossip_puller), 0, ZMQ_POLLIN, 0 },
     { static_cast<void *>(lgossip_puller), 0, ZMQ_POLLIN, 0 },
-    { static_cast<void *>(lredistribute_puller), 0, ZMQ_POLLIN, 0 },
-    { static_cast<void *>(depart_puller), 0, ZMQ_POLLIN, 0 }
+    { static_cast<void *>(lredistribute_puller), 0, ZMQ_POLLIN, 0 }
   };
 
   auto gossip_start = std::chrono::system_clock::now();
@@ -380,44 +377,6 @@ void worker_routine (zmq::context_t* context, string ip, int thread_id) {
       }
     }
 
-    if (pollitems[4].revents & ZMQ_POLLIN) { // process a departure 
-      cout << "Thread " + to_string(thread_id) + " received departure command.\n";
-
-      string device_name = zmq_util::recv_string(&depart_puller);
-
-      changeset_data* data = new changeset_data();
-      data->first = port;
-
-      // for every key this thread is responsible for, add it to the changeset
-      // wrapper
-      for (auto it = key_set.begin(); it != key_set.end(); it++) {
-        (data->second).insert(*it);
-      }
-
-      zmq_util::send_msg((void*)data, &changeset_address_requester);
-      zmq::message_t msg;
-      zmq_util::recv_msg(&changeset_address_requester, msg);
-
-      changeset_address* res = *(changeset_address **)(msg.data());
-      send_gossip(res, pushers, ip, thread_id);
-      delete res;
-
-      string shell_command;
-      // remove the volume locally
-      if (enable_ebs) {
-        shell_command = "scripts/remove_volume.sh " + device_name + " " + to_string(thread_id);
-      } else {
-        shell_command = "scripts/remove_volume_dummy.sh " + device_name + " " + to_string(thread_id);
-      }
-
-      system(shell_command.c_str());
-      zmq_util::send_string(device_name + ":" + to_string(thread_id), &pushers[LOCAL_DEPART_DONE_ADDR]);
-      
-      // break because we have now successfully removed the thread and are
-      // ending its execution
-      break;
-    }
-
     gossip_end = std::chrono::system_clock::now();
     // check whether we should gossip
     if (chrono::duration_cast<std::chrono::seconds>(gossip_end-gossip_start).count() >= PERIOD || local_changeset.size() >= THRESHOLD) {
@@ -468,118 +427,9 @@ void worker_routine (zmq::context_t* context, string ip, int thread_id) {
   }
 }
 
-// TODO: add_thread currently not used anywhere. before we use it, we'll have
-// to figure out how to / if we can add an EBS volume to an existing pod... if
-// not, we'll need some sort of workaround.
-void add_thread(map<string, int>& ebs_device_map, 
-    unordered_map<int, string>& inverse_ebs_device_map, 
-    vector<thread>& worker_threads,
-    local_hash_t& local_hash_ring,
-    unordered_map<string, storage_key_info>& placement,
-    set<int>& active_thread_id,
-    int next_thread_id,
-    string ip,
-    zmq::context_t& context,
-    SocketCache& pushers) {
-
-  cout << "Adding a new thread.\n";
-  string ebs_device_id;
-
-  if (ebs_device_map.size() == 0) {
-    ebs_device_id = "ba";
-    ebs_device_map[ebs_device_id] = next_thread_id;
-    inverse_ebs_device_map[next_thread_id] = ebs_device_id;
-  } else {
-    bool has_slot = false;
-    for (auto it = ebs_device_map.begin(); it != ebs_device_map.end(); it++) {
-      if (it->second == -1) {
-        has_slot = true;
-        ebs_device_id = it->first;
-
-        ebs_device_map[it->first] = next_thread_id;
-        inverse_ebs_device_map[next_thread_id] = it->first;
-        break;
-      }
-    }
-
-    if (!has_slot) {
-      ebs_device_id = getNextDeviceID((ebs_device_map.rbegin())->first);
-      ebs_device_map[ebs_device_id] = next_thread_id;
-      inverse_ebs_device_map[next_thread_id] = ebs_device_id;
-    }
-  }
-
-  cout << "Adding device with ID " + ebs_device_id + " and thread with ID " + to_string(next_thread_id) + ".\n";
-
-  string shell_command;
-  if (enable_ebs) {
-    shell_command = "scripts/add_volume.sh " + ebs_device_id + " 10 " + to_string(next_thread_id);
-  } else {
-    shell_command = "scripts/add_volume_dummy.sh " + ebs_device_id + " 10 " + to_string(next_thread_id);
-  }
-
-  system(shell_command.c_str());
-  worker_threads.push_back(thread(worker_routine, &context, ip, next_thread_id));
-
-  active_thread_id.insert(next_thread_id);
-  local_hash_ring.insert(worker_node_t(ip, next_thread_id));
-
-  // repartition data
-  unordered_map<string, redistribution_address*> redistribution_map;
-
-  string target_address = ip + ":" + to_string(SERVER_PORT + next_thread_id);
-  for (auto it = placement.begin(); it != placement.end(); it++) {
-
-    auto result = responsible<worker_node_t, local_hasher>(it->first, it->second.local_replication_, local_hash_ring, target_address);
-
-    bool resp = result.first;
-
-    if (resp) {
-      cout << "The new thread is responsible for key " + it->first + ".\n";
-      string sender_address = result.second->local_redistribute_addr_;
-      cout << "The sender address is " + sender_address + ".\n";
-
-      if (redistribution_map.find(sender_address) == redistribution_map.end()) {
-        redistribution_map[sender_address] = new redistribution_address();
-      }
-
-      (*redistribution_map[sender_address])[target_address].insert(pair<string, bool>(it->first, true));
-    }
-  }
-
-  for (auto it = redistribution_map.begin(); it != redistribution_map.end(); it++) {
-    zmq_util::send_msg((void*)it->second, &pushers[it->first]);
-  }
-
-  next_thread_id += 1;
-}
-
-void remove_thread(set<int>& active_thread_id,
-    local_hash_t& local_hash_ring,
-    unordered_map<int, string>& inverse_ebs_device_map,
-    string ip,
-    SocketCache& pushers,
-    unordered_map<string, size_t>& worker_thread_storage) {
-
-  if (active_thread_id.rbegin() == active_thread_id.rend()) {
-    cout << "Error: No remaining threads are running. Nothing to remove.\n";
-  } else {
-    int target_thread_id = *(active_thread_id.rbegin());
-    cout << "Removing thread " + to_string(target_thread_id) + ".\n";
-
-    worker_node_t wnode = worker_node_t(ip, target_thread_id);
-    local_hash_ring.erase(wnode);
-    active_thread_id.erase(target_thread_id);
-    worker_thread_storage.erase(to_string(target_thread_id));
-
-    string device_id = inverse_ebs_device_map[target_thread_id];
-    zmq_util::send_string(device_id, &pushers[wnode.local_depart_addr_]);
-  }
-}
-
 int main(int argc, char* argv[]) {
-  if (argc != 3) {
-    cerr << "usage:" << argv[0] << " <new_node> <enable_ebs>" << endl;
+  if (argc != 2) {
+    cerr << "usage:" << argv[0] << " <new_node>" << endl;
     return 1;
   }
 
@@ -588,20 +438,10 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  if (string(argv[2]) != "y" && string(argv[2]) != "n") {
-    cerr << "Invalid second argument: " << string(argv[2]) << "." << endl;
-    return 1;
-  }
-
   string ip = get_ip("server");
   string new_node = argv[1];
-  if (string(argv[2]) == "y") {
-    enable_ebs = true;
-  } else {
-    enable_ebs = false;
-  }
 
-  master_node_t mnode = master_node_t(ip, "E");
+  master_node_t mnode = master_node_t(ip, NODE_TYPE);
 
   // prepare the zmq context
   zmq::context_t context(1);
@@ -609,7 +449,7 @@ int main(int argc, char* argv[]) {
   SocketCache requesters(&context, ZMQ_REQ);
 
   // create our hash rings
-  global_hash_t global_ebs_hash_ring;
+  global_hash_t global_hash_ring;
   local_hash_t local_hash_ring;
   unordered_map<string, storage_key_info> placement;
 
@@ -643,11 +483,11 @@ int main(int argc, char* argv[]) {
   if (new_node == "n") {
     address.open("conf/server/start_servers.txt");
     // add itself to the ring
-    global_ebs_hash_ring.insert(mnode);
+    global_hash_ring.insert(mnode);
 
     // add all other servers
     while (getline(address, ip_line)) {
-      global_ebs_hash_ring.insert(master_node_t(ip_line, "E"));
+      global_hash_ring.insert(master_node_t(ip_line, NODE_TYPE));
     }
     address.close();
   } else { // get server address from the seed node
@@ -657,76 +497,47 @@ int main(int argc, char* argv[]) {
 
     // tell the seed node that you are joining
     zmq::socket_t addr_requester(context, ZMQ_REQ);
-    addr_requester.connect(master_node_t(ip_line, "E").seed_connection_connect_addr_);
+    addr_requester.connect(master_node_t(ip_line, NODE_TYPE).seed_connection_connect_addr_);
     zmq_util::send_string("join", &addr_requester);
 
     // receive and add all the addresses that seed node sent
     vector<string> addresses;
     split(zmq_util::recv_string(&addr_requester), '|', addresses);
     for (auto it = addresses.begin(); it != addresses.end(); it++) {
-      global_ebs_hash_ring.insert(master_node_t(*it, "E"));
+      global_hash_ring.insert(master_node_t(*it, NODE_TYPE));
     }
 
     // add itself to global hash ring
-    global_ebs_hash_ring.insert(mnode);
+    global_hash_ring.insert(mnode);
   }
 
-  // this map is ordered, so that we can figure out the device name when adding
-  // new devices
-  map<string, int> ebs_device_map;
-
-  unordered_map<int, string> inverse_ebs_device_map;
   vector<thread> worker_threads;
 
-  // this is the smallest device name that we can have because of EBS
-  // idiosyncrasies
-  string eid = "ba";
-
-  // create the initial volumes and start the initial threads based on
-  // EBS_THREAD_NUM
+  // start the initial threads based on EBS_THREAD_NUM
   for (int thread_id = 1; thread_id <= EBS_THREAD_NUM; thread_id++) {
-    ebs_device_map[eid] = thread_id;
-    inverse_ebs_device_map[thread_id] = eid;
-
-    cout << "device id to be added is " + eid + "\n";
     cout << "thread id is " + to_string(thread_id) + "\n";
-
-    string shell_command;
-    if (enable_ebs) {
-      shell_command = "scripts/add_volume.sh " + eid + " 10 " + to_string(thread_id);
-    }
-    else {
-      shell_command = "scripts/add_volume_dummy.sh " + eid + " 10 " + to_string(thread_id);
-    }
-
-    system(shell_command.c_str());
-    eid = getNextDeviceID(eid);
     worker_threads.push_back(thread(worker_routine, &context, ip, thread_id));
     local_hash_ring.insert(worker_node_t(ip, thread_id));
   }
 
-  set<int> active_thread_id = set<int>();
-  for (int i = 1; i <= EBS_THREAD_NUM; i++) {
-    active_thread_id.insert(i);
-  }
-
   if (new_node == "y") {
     // notify other servers that there is a new node
-    for (auto it = global_ebs_hash_ring.begin(); it != global_ebs_hash_ring.end(); it++) {
+    for (auto it = global_hash_ring.begin(); it != global_hash_ring.end(); it++) {
       if (it->second.ip_.compare(ip) != 0) {
         zmq_util::send_string(ip, &pushers[(it->second).node_join_connect_addr_]);
       }
     }
   }
 
+  string msg = "join:" + string(NODE_TYPE) + ":" + ip;
   // notify proxies that this node has joined the service
   for (auto it = proxy_address.begin(); it != proxy_address.end(); it++) {
-    zmq_util::send_string("join:E:" + ip, &pushers[proxy_node_t(*it).notify_connect_addr_]);
+    zmq_util::send_string(msg, &pushers[proxy_node_t(*it).notify_connect_addr_]);
   }
 
   // notify monitoring nodes that this node has joined the service
   for (auto it = monitoring_address.begin(); it != monitoring_address.end(); it++) {
-    zmq_util::send_string("join:E:" + ip, &pushers[monitoring_node_t(*it).notify_connect_addr_]);
+    zmq_util::send_string(msg, &pushers[monitoring_node_t(*it).notify_connect_addr_]);
   }
 
   // responsible for sending the server address to a new node
@@ -749,10 +560,6 @@ int main(int argc, char* argv[]) {
   zmq::socket_t changeset_address_responder(context, ZMQ_REP);
   changeset_address_responder.bind(CHANGESET_ADDR);
 
-  // responsible for monitoring when a worker has finished departing
-  zmq::socket_t depart_done_puller(context, ZMQ_PULL);
-  depart_done_puller.bind(LOCAL_DEPART_DONE_ADDR);
-
   // responsible for listening for a command that this node should leave
   zmq::socket_t self_depart_responder(context, ZMQ_REP);
   self_depart_responder.bind(SELF_DEPART_BIND_ADDR);
@@ -771,13 +578,10 @@ int main(int argc, char* argv[]) {
                                        {static_cast<void*>(depart_puller), 0, ZMQ_POLLIN, 0},
                                        {static_cast<void*>(key_address_responder), 0, ZMQ_POLLIN, 0},
                                        {static_cast<void*>(changeset_address_responder), 0, ZMQ_POLLIN, 0},
-                                       {static_cast<void*>(depart_done_puller), 0, ZMQ_POLLIN, 0},
                                        {static_cast<void*>(self_depart_responder), 0, ZMQ_POLLIN, 0},
                                        {static_cast<void*>(replication_factor_change_puller), 0, ZMQ_POLLIN, 0},
                                        {static_cast<void*>(storage_consumption_puller), 0, ZMQ_POLLIN, 0}
                                      };
-
-  int next_thread_id = EBS_THREAD_NUM + 1;
 
   auto storage_start = std::chrono::system_clock::now();
   auto storage_end = std::chrono::system_clock::now();
@@ -791,7 +595,7 @@ int main(int argc, char* argv[]) {
       string request = zmq_util::recv_string(&addr_responder);
 
       string addresses;
-      for (auto it = global_ebs_hash_ring.begin(); it != global_ebs_hash_ring.end(); it++) {
+      for (auto it = global_hash_ring.begin(); it != global_hash_ring.end(); it++) {
         addresses += (it->second.ip_ + "|");
       }
 
@@ -803,10 +607,10 @@ int main(int argc, char* argv[]) {
     if (pollitems[1].revents & ZMQ_POLLIN) {
       string new_server_ip = zmq_util::recv_string(&join_puller);
       cout << "Received a node join. New node is " << new_server_ip << ".\n";
-      master_node_t new_node = master_node_t(new_server_ip, "E");
+      master_node_t new_node = master_node_t(new_server_ip, NODE_TYPE);
 
       // update global hash ring
-      global_ebs_hash_ring.insert(new_node);
+      global_hash_ring.insert(new_node);
 
       // a map for each local worker that has to redistribute to the remote
       // node
@@ -822,7 +626,7 @@ int main(int argc, char* argv[]) {
         string key = it->first;
         storage_key_info info = it->second;
 
-        auto result = responsible<master_node_t, global_hasher>(key, info.global_ebs_replication_, global_ebs_hash_ring, new_node.id_);
+        auto result = responsible<master_node_t, global_hasher>(key, info.global_ebs_replication_, global_hash_ring, new_node.id_);
 
         if (result.first && (result.second->ip_.compare(ip) == 0)) {
           key_to_query.insert(it->first);
@@ -875,24 +679,24 @@ int main(int argc, char* argv[]) {
       cout << "Received departure for node " << departing_server_ip << ".\n";
 
       // update hash ring
-      global_ebs_hash_ring.erase(master_node_t(departing_server_ip, "E"));
+      global_hash_ring.erase(master_node_t(departing_server_ip, NODE_TYPE));
     }
 
     if (pollitems[3].revents & ZMQ_POLLIN) {
       cout << "Received a key address request.\n";
 
-      string key_req = zmq_util::recv_string(&key_address_responder);
-      communication::Key_Request req;
-      req.ParseFromString(key_req);
+      string serialized_key_req = zmq_util::recv_string(&key_address_responder);
+      communication::Key_Request key_req;
+      key_req.ParseFromString(serialized_key_req);
 
-      string sender = req.sender();
-      communication::Key_Response res;
+      string sender = key_req.sender();
+      communication::Key_Response key_resp;
 
       // for every requested key
-      for (int i = 0; i < req.tuple_size(); i++) {
-        string key = req.tuple(i).key();
-        int gmr = req.tuple(i).global_memory_replication();
-        int ger = req.tuple(i).global_ebs_replication();
+      for (int i = 0; i < key_req.tuple_size(); i++) {
+        string key = key_req.tuple(i).key();
+        int gmr = key_req.tuple(i).global_memory_replication();
+        int ger = key_req.tuple(i).global_ebs_replication();
         cout << "Received a key request for key " + key + ".\n";
 
         // fill in placement metadata only if not already exist
@@ -901,10 +705,10 @@ int main(int argc, char* argv[]) {
         }
 
         // check if the node is responsible for this key
-        auto result = responsible<master_node_t, global_hasher>(key, placement[key].global_ebs_replication_, global_ebs_hash_ring, mnode.id_);
+        auto result = responsible<master_node_t, global_hasher>(key, placement[key].global_ebs_replication_, global_hash_ring, mnode.id_);
 
         if (result.first) {
-          communication::Key_Response_Tuple* tp = res.add_tuple();
+          communication::Key_Response_Tuple* tp = key_resp.add_tuple();
           tp->set_key(key);
 
           // find all the local worker threads that are assigned to this key
@@ -923,11 +727,11 @@ int main(int argc, char* argv[]) {
             }
           }
         }
+      }
 
-        string response;
-        res.SerializeToString(&response);
-        zmq_util::send_string(response, &key_address_responder);
-      } 
+      string serialized_key_resp;
+      key_resp.SerializeToString(&serialized_key_resp);
+      zmq_util::send_string(serialized_key_resp, &key_address_responder);
     }
 
     if (pollitems[4].revents & ZMQ_POLLIN) {
@@ -964,18 +768,18 @@ int main(int argc, char* argv[]) {
 
         // second, check the global ebs ring for any nodes that might also be
         // responsible for this key
-        auto pos = global_ebs_hash_ring.find(key);
+        auto pos = global_hash_ring.find(key);
         for (int i = 0; i < placement[key].global_ebs_replication_; i++) {
           if (pos->second.ip_.compare(ip) != 0) {
             node_map[pos->second].insert(key);
           }
 
-          if (++pos == global_ebs_hash_ring.end()) {
-            pos = global_ebs_hash_ring.begin();
+          if (++pos == global_hash_ring.end()) {
+            pos = global_hash_ring.begin();
           }
         }
 
-        // finally, check if the key has replica on the memory tier
+        // finally, check if the key has replica on the other tier
         if (placement[key].global_memory_replication_ != 0) {
           key_to_proxy.insert(key);
         }
@@ -1002,7 +806,7 @@ int main(int argc, char* argv[]) {
         int tid = 1 + rand() % PROXY_THREAD_NUM;
         string target_proxy_address = proxy_worker_thread_t(proxy_address[rand() % proxy_address.size()], tid).proxy_gossip_connect_addr_;
         // get key address
-        communication::Key_Response resp = get_key_address<storage_key_info>(target_proxy_address, "M", key_to_proxy, requesters, placement);
+        communication::Key_Response resp = get_key_address<storage_key_info>(target_proxy_address, NODE_TYPE, key_to_proxy, requesters, placement);
 
         // for each key, add the address of *every* (there can be multiple)
         // worker thread on the other node that should receive this key
@@ -1019,35 +823,24 @@ int main(int argc, char* argv[]) {
     }
 
     if (pollitems[5].revents & ZMQ_POLLIN) {
-      // we wait for this message to come back from the worker thread because
-      // we want to avoid a race condition where the master thread tries to
-      // reuse the volume name before it's removed
-      vector<string> v;
-      split(zmq_util::recv_string(&depart_done_puller), ':', v);
-      cout << "Thread " + v[1] + " has departed.\n";
-
-      ebs_device_map[v[0]] = -1;
-      inverse_ebs_device_map.erase(stoi(v[1]));
-    }
-
-    if (pollitems[6].revents & ZMQ_POLLIN) {
       cout << "Node is departing.\n";
 
-      global_ebs_hash_ring.erase(mnode);
-      for (auto it = global_ebs_hash_ring.begin(); it != global_ebs_hash_ring.end(); it++) {
+      global_hash_ring.erase(mnode);
+      for (auto it = global_hash_ring.begin(); it != global_hash_ring.end(); it++) {
         zmq_util::send_string(ip, &pushers[it->second.node_depart_connect_addr_]);
       }
       
+      string msg = "depart:" + string(NODE_TYPE) + ":" + ip;
       // notify proxies
       for (auto it = proxy_address.begin(); it != proxy_address.end(); it++) {
-        zmq_util::send_string("depart:E:" + ip, &pushers[proxy_node_t(*it).notify_connect_addr_]);
+        zmq_util::send_string(msg, &pushers[proxy_node_t(*it).notify_connect_addr_]);
       }
 
       // form the key_request map
       unordered_map<string, communication::Key_Request> key_request_map;
       for (auto it = placement.begin(); it != placement.end(); it++) {
         string key = it->first;
-        auto pos = global_ebs_hash_ring.find(key);
+        auto pos = global_hash_ring.find(key);
 
         for (int i = 0; i < placement[key].global_ebs_replication_; i++) {
           key_request_map[pos->second.key_exchange_connect_addr_].set_sender("server");
@@ -1056,8 +849,8 @@ int main(int argc, char* argv[]) {
           tp->set_global_memory_replication(placement[key].global_memory_replication_);
           tp->set_global_ebs_replication(placement[key].global_ebs_replication_);
 
-          if (++pos == global_ebs_hash_ring.end()) {
-            pos = global_ebs_hash_ring.begin();
+          if (++pos == global_hash_ring.end()) {
+            pos = global_hash_ring.begin();
           }
         }
       }
@@ -1098,28 +891,13 @@ int main(int argc, char* argv[]) {
       for (auto it = redistribution_map.begin(); it != redistribution_map.end(); it++) {
         zmq_util::send_msg((void*)it->second, &pushers[it->first]);
       }
-
-      cout << "Killing all EBS instances.\n";
-
-      for (auto it = inverse_ebs_device_map.begin(); it != inverse_ebs_device_map.end(); it++) {
-        active_thread_id.erase(it->first);
-        local_hash_ring.erase(worker_node_t(ip, it->first));
-        string shell_command;
-        if (enable_ebs) {
-          shell_command = "scripts/remove_volume.sh " + it->second + " " + to_string(it->first);
-        } else {
-          shell_command = "scripts/remove_volume_dummy.sh " + it->second + " " + to_string(it->first);
-        }
-
-        system(shell_command.c_str());
-      }
       
       // TODO: once we break here, I don't think that the threads will have
       // finished. they will still be looping.
       break;
     }
 
-    if (pollitems[7].revents & ZMQ_POLLIN) {
+    if (pollitems[6].revents & ZMQ_POLLIN) {
       cout << "Received replication factor change request\n";
 
       string placement_req = zmq_util::recv_string(&replication_factor_change_puller);
@@ -1146,30 +924,30 @@ int main(int argc, char* argv[]) {
         }
 
         // first, check whether the node is responsible for the key before the replication factor change
-        auto result = responsible<master_node_t, global_hasher>(key, placement[key].global_ebs_replication_, global_ebs_hash_ring, mnode.id_);
+        auto result = responsible<master_node_t, global_hasher>(key, placement[key].global_ebs_replication_, global_hash_ring, mnode.id_);
         // update placement info
         placement[key].global_memory_replication_ = gmr;
         placement[key].global_ebs_replication_ = ger;
         // proceed only if the node is responsible for the key before the replication factor change
         if (result.first) {
           // check the global ring and request worker addresses from other node's master thread
-          auto pos = global_ebs_hash_ring.find(key);
+          auto pos = global_hash_ring.find(key);
           for (int i = 0; i < placement[key].global_ebs_replication_; i++) {
             if (pos->second.ip_.compare(ip) != 0) {
               node_map[pos->second].insert(key);
             }
-            if (++pos == global_ebs_hash_ring.end()) {
-              pos = global_ebs_hash_ring.begin();
+            if (++pos == global_hash_ring.end()) {
+              pos = global_hash_ring.begin();
             }
           }
 
-          // check if the key has replica on the memory tier
+          // check if the key has replica on the other tier
           if (placement[key].global_memory_replication_ != 0) {
             key_to_proxy.insert(key);
           }
 
           // check if the key has to be removed under the new replication factor
-          result = responsible<master_node_t, global_hasher>(key, placement[key].global_ebs_replication_, global_ebs_hash_ring, mnode.id_);
+          result = responsible<master_node_t, global_hasher>(key, placement[key].global_ebs_replication_, global_hash_ring, mnode.id_);
           if (result.first) {
             key_remove_map[key] = false;
           } else {
@@ -1223,7 +1001,7 @@ int main(int argc, char* argv[]) {
         int tid = 1 + rand() % PROXY_THREAD_NUM;
         string target_proxy_address = proxy_worker_thread_t(proxy_address[rand() % proxy_address.size()], tid).proxy_gossip_connect_addr_;
         // get key address
-        communication::Key_Response resp = get_key_address<storage_key_info>(target_proxy_address, "M", key_to_proxy, requesters, placement);
+        communication::Key_Response resp = get_key_address<storage_key_info>(target_proxy_address, NODE_TYPE, key_to_proxy, requesters, placement);
 
         // for each key in the response
         for (int i = 0; i < resp.tuple_size(); i++) {
@@ -1265,7 +1043,7 @@ int main(int argc, char* argv[]) {
       }
     }
 
-    if (pollitems[8].revents & ZMQ_POLLIN) {
+    if (pollitems[7].revents & ZMQ_POLLIN) {
       cerr << "received storage update from worker thread\n";
       zmq::message_t msg;
       zmq_util::recv_msg(&storage_consumption_puller, msg);
@@ -1285,7 +1063,7 @@ int main(int argc, char* argv[]) {
 
       for (auto it = worker_thread_storage.begin(); it != worker_thread_storage.end(); it++) {
         communication::Request_Tuple* tp = req.add_tuple();
-        tp->set_key(mnode.ip_ + "_E_" + it->first + "_storage");
+        tp->set_key(mnode.ip_ + "_" + NODE_TYPE + "_" + it->first + "_storage");
         tp->set_value(to_string(it->second));
       }
       string serialized_req;

--- a/kv_store/lww_kvs/kvs_monitoring.cpp
+++ b/kv_store/lww_kvs/kvs_monitoring.cpp
@@ -169,12 +169,12 @@ int main(int argc, char* argv[]) {
   address.close();
 
   // read address of management node from conf file
-  /*address_t management_address;
+  address_t management_address;
 
   address.open("conf/monitoring/management_ip.txt");
   getline(address, ip_line);
   management_address = ip_line;
-  address.close();*/
+  address.close();
 
 
   zmq::context_t context(1);
@@ -234,25 +234,6 @@ int main(int argc, char* argv[]) {
         cerr << "ebs hash ring size is " + to_string(global_ebs_hash_ring.size()) + "\n";
       }
     }
-
-    /*if (pollitems[1].revents & ZMQ_POLLIN) {
-      cerr << "received replication factor query\n";
-
-      string key = zmq_util::recv_string(&replication_factor_query_responder);
-
-      if (placement.find(key) == placement.end()) {
-        placement[key] = key_info(DEFAULT_GLOBAL_MEMORY_REPLICATION, DEFAULT_GLOBAL_EBS_REPLICATION);
-      }
-
-      communication::Replication_Factor replication_factor;
-      replication_factor.set_global_memory_replication(placement[key].global_memory_replication_);
-      replication_factor.set_global_ebs_replication(placement[key].global_ebs_replication_);
-
-      string response;
-
-      replication_factor.SerializeToString(&response);
-      zmq_util::send_string(response, &replication_factor_query_responder);
-    }*/
 
     hotness_end = std::chrono::system_clock::now();
 
@@ -346,7 +327,7 @@ int main(int argc, char* argv[]) {
         }
       }
 
-      /*size_t total_memory_consumption = 0;
+      size_t total_memory_consumption = 0;
       size_t total_ebs_consumption = 0;
       int memory_node_count = 0;
       int ebs_volume_count = 0;
@@ -375,7 +356,7 @@ int main(int argc, char* argv[]) {
         cerr << "trigger add ebs node\n";
         string shell_command = "curl -X POST https://" + management_address + "/ebs";
         system(shell_command.c_str());
-      }*/
+      }
 
       storage_start = std::chrono::system_clock::now();
     }

--- a/kv_store/lww_kvs/kvs_monitoring.cpp
+++ b/kv_store/lww_kvs/kvs_monitoring.cpp
@@ -169,12 +169,12 @@ int main(int argc, char* argv[]) {
   address.close();
 
   // read address of management node from conf file
-  address_t management_address;
+  /*address_t management_address;
 
   address.open("conf/monitoring/management_ip.txt");
   getline(address, ip_line);
   management_address = ip_line;
-  address.close();
+  address.close();*/
 
 
   zmq::context_t context(1);
@@ -346,7 +346,7 @@ int main(int argc, char* argv[]) {
         }
       }
 
-      size_t total_memory_consumption = 0;
+      /*size_t total_memory_consumption = 0;
       size_t total_ebs_consumption = 0;
       int memory_node_count = 0;
       int ebs_volume_count = 0;
@@ -375,7 +375,7 @@ int main(int argc, char* argv[]) {
         cerr << "trigger add ebs node\n";
         string shell_command = "curl -X POST https://" + management_address + "/ebs";
         system(shell_command.c_str());
-      }
+      }*/
 
       storage_start = std::chrono::system_clock::now();
     }

--- a/kv_store/lww_kvs/kvs_proxy.cpp
+++ b/kv_store/lww_kvs/kvs_proxy.cpp
@@ -471,13 +471,8 @@ void proxy_worker_routine(zmq::context_t* context,
         // allows the metadata thread to answer lightweight requests only
         for (int i = 0; i < server_res.tuple_size(); i++) {
           key = server_res.tuple(i).key();
-          if (it->first.tier_ == "E") {
-            for (int j = 0; j < server_res.tuple(i).address_size(); j++) {
-              key_worker_map[key].insert(server_res.tuple(i).address(j).addr());
-            }
-          } else {
-            // we only have one address for memory tier
-            key_worker_map[key].insert(server_res.tuple(i).address(0).addr());
+          for (int j = 0; j < server_res.tuple(i).address_size(); j++) {
+            key_worker_map[key].insert(server_res.tuple(i).address(j).addr());
           }
         }
       }

--- a/kv_store/lww_kvs/kvs_proxy.cpp
+++ b/kv_store/lww_kvs/kvs_proxy.cpp
@@ -416,7 +416,7 @@ void proxy_worker_routine(zmq::context_t* context,
       string key_req = zmq_util::recv_string(&gossip_responder);
       communication::Key_Request req;
       req.ParseFromString(key_req);
-      string target_tier = req.target_tier();
+      string source_tier = req.source_tier();
       // this data structure is for keeping track of the mapping between each key and the workers responsible for the key
       unordered_map<string, unordered_set<address_t>> key_worker_map;
       vector<master_node_t> server_nodes;
@@ -426,10 +426,16 @@ void proxy_worker_routine(zmq::context_t* context,
       // loop through "req" to create the key request map for sending key address requests
       for (int i = 0; i < req.tuple_size(); i++) {
         string key = req.tuple(i).key();
-        if (target_tier == "M") {
-          server_nodes = get_nodes(key, global_memory_hash_ring, nullptr, placement->find(key)->second.global_memory_replication_.load(), placement->find(key)->second.global_ebs_replication_.load());
-        } else {
+        // update the placement map
+        if (placement->find(key) == placement->end()) {
+          placement->emplace(std::piecewise_construct,
+                             std::forward_as_tuple(key),
+                             std::forward_as_tuple(req.tuple(i).global_memory_replication(), req.tuple(i).global_ebs_replication()));
+        }
+        if (source_tier == "M") {
           server_nodes = get_nodes(key, nullptr, global_ebs_hash_ring, placement->find(key)->second.global_memory_replication_.load(), placement->find(key)->second.global_ebs_replication_.load());
+        } else {
+          server_nodes = get_nodes(key, global_memory_hash_ring, nullptr, placement->find(key)->second.global_memory_replication_.load(), placement->find(key)->second.global_ebs_replication_.load());
         }
 
         if (server_nodes.size() == 0) {

--- a/kv_store/lww_kvs/message.proto
+++ b/kv_store/lww_kvs/message.proto
@@ -42,7 +42,7 @@ message Key_Request {
   }
   required string sender = 1;
   repeated Tuple tuple = 2;
-  optional string target_tier = 3;
+  optional string source_tier = 3;
 }
 
 message Key_Response {


### PR DESCRIPTION
Now the memory tier and the ebs tier use near identical codebase. The majority of the difference comes from the request handling process (writing to memory buffer vs writing to file)

I tested it manually without using k8s and it seems working (I used 2 mem nodes + 1 ebs node)

A few questions:
1. I saw in `ebs-pod.yml` that the mount paths are of the form `/ebs/ebs1` instead of `/ebs/ebs_1`. I guess this could be a problem? Should we fix the yml file's path name to be consistent with the path name in the code?
2. I am assuming the yml file will automatically create the directories such as `/ebs/ebs_1` for us? Have you tested we have permission to write to this location (I am asking because when I tried to test manually, I have to set the permission of the directory to $USER in order to write to it)? If not could you give it a test when you get a chance?
3. I removed the `n` in `start.sh` when we spin up ebs nodes since we no longer need this option. Is it the only place I should change? 

Thanks!