### PR TITLE
runtime configurable thread numbers and rep factors

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -20,7 +20,6 @@ thread:
   memory: 4
   ebs: 4
   routing: 4
-  benchmark: 4
 replication:
   memory: 1
   ebs: 0

--- a/conf/config.yml
+++ b/conf/config.yml
@@ -16,3 +16,13 @@ server:
   seed_ip: 127.0.0.1
   ip: 127.0.0.1
 ebs: ./
+thread:
+  memory: 4
+  ebs: 4
+  routing: 4
+  benchmark: 4
+replication:
+  memory: 1
+  ebs: 0
+  minimum: 1
+  local: 1

--- a/conf/config_benchmark.yaml
+++ b/conf/config_benchmark.yaml
@@ -1,0 +1,3 @@
+thread:
+  routing: 4
+  benchmark: 4

--- a/conf/config_user.yaml
+++ b/conf/config_user.yaml
@@ -1,0 +1,3 @@
+thread:
+  routing: 4
+  benchmark: 4

--- a/src/bedrock/monitoring.cpp
+++ b/src/bedrock/monitoring.cpp
@@ -21,6 +21,13 @@
 using namespace std;
 using address_t = string;
 
+unsigned MEMORY_THREAD_NUM;
+unsigned EBS_THREAD_NUM;
+
+unsigned DEFAULT_GLOBAL_MEMORY_REPLICATION;
+unsigned DEFAULT_GLOBAL_EBS_REPLICATION;
+unsigned MINIMUM_REPLICA_NUMBER;
+
 // read-only per-tier metadata
 unordered_map<unsigned, tier_data> tier_data_map;
 
@@ -605,6 +612,15 @@ int main(int argc, char* argv[]) {
   YAML::Node conf = YAML::LoadFile("conf/config.yml")["monitoring"];
   string ip = conf["ip"].as<string>();
 
+  YAML::Node conf_thread = YAML::LoadFile("conf/config.yml")["thread"];
+  MEMORY_THREAD_NUM = conf_thread["memory"].as<int>();
+  EBS_THREAD_NUM = conf_thread["ebs"].as<int>();
+
+  YAML::Node conf_replication = YAML::LoadFile("conf/config.yml")["replication"];
+  DEFAULT_GLOBAL_MEMORY_REPLICATION = conf_replication["memory"].as<int>();
+  DEFAULT_GLOBAL_EBS_REPLICATION = conf_replication["ebs"].as<int>();
+  MINIMUM_REPLICA_NUMBER = conf_replication["minimum"].as<int>();
+
   tier_data_map[1] = tier_data(MEMORY_THREAD_NUM, DEFAULT_GLOBAL_MEMORY_REPLICATION, MEM_NODE_CAPACITY);
   tier_data_map[2] = tier_data(EBS_THREAD_NUM, DEFAULT_GLOBAL_EBS_REPLICATION, EBS_NODE_CAPACITY);
 
@@ -622,7 +638,7 @@ int main(int argc, char* argv[]) {
   // keep track of the keys' replication info
   unordered_map<string, key_info> placement;
   // warm up for benchmark
-  warmup(placement);
+  //warmup(placement);
 
   // keep track of the keys' access by worker address
   unordered_map<string, unordered_map<address_t, unsigned>> key_access_frequency;

--- a/src/bedrock/routing.cpp
+++ b/src/bedrock/routing.cpp
@@ -17,14 +17,6 @@
 
 using namespace std;
 
-unsigned MEMORY_THREAD_NUM;
-unsigned EBS_THREAD_NUM;
-unsigned ROUTING_THREAD_NUM;
-
-unsigned DEFAULT_GLOBAL_MEMORY_REPLICATION;
-unsigned DEFAULT_GLOBAL_EBS_REPLICATION;
-unsigned DEFAULT_LOCAL_REPLICATION;
-
 // read-only per-tier metadata
 unordered_map<unsigned, tier_data> tier_data_map;
 
@@ -359,15 +351,14 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  YAML::Node conf_thread = YAML::LoadFile("conf/config.yml")["thread"];
-  MEMORY_THREAD_NUM = conf_thread["memory"].as<int>();
-  EBS_THREAD_NUM = conf_thread["ebs"].as<int>();
-  ROUTING_THREAD_NUM = conf_thread["routing"].as<int>();
+  YAML::Node conf = YAML::LoadFile("conf/config.yml");
+  MEMORY_THREAD_NUM = conf["thread"]["memory"].as<int>();
+  EBS_THREAD_NUM = conf["thread"]["ebs"].as<int>();
+  ROUTING_THREAD_NUM = conf["thread"]["routing"].as<int>();
 
-  YAML::Node conf_replication = YAML::LoadFile("conf/config.yml")["replication"];
-  DEFAULT_GLOBAL_MEMORY_REPLICATION = conf_replication["memory"].as<int>();
-  DEFAULT_GLOBAL_EBS_REPLICATION = conf_replication["ebs"].as<int>();
-  DEFAULT_LOCAL_REPLICATION = conf_replication["local"].as<int>();
+  DEFAULT_GLOBAL_MEMORY_REPLICATION = conf["replication"]["memory"].as<int>();
+  DEFAULT_GLOBAL_EBS_REPLICATION = conf["replication"]["ebs"].as<int>();
+  DEFAULT_LOCAL_REPLICATION = conf["replication"]["local"].as<int>();
 
   tier_data_map[1] = tier_data(MEMORY_THREAD_NUM, DEFAULT_GLOBAL_MEMORY_REPLICATION, MEM_NODE_CAPACITY);
   tier_data_map[2] = tier_data(EBS_THREAD_NUM, DEFAULT_GLOBAL_EBS_REPLICATION, EBS_NODE_CAPACITY);

--- a/src/bedrock/routing.cpp
+++ b/src/bedrock/routing.cpp
@@ -17,6 +17,14 @@
 
 using namespace std;
 
+unsigned MEMORY_THREAD_NUM;
+unsigned EBS_THREAD_NUM;
+unsigned ROUTING_THREAD_NUM;
+
+unsigned DEFAULT_GLOBAL_MEMORY_REPLICATION;
+unsigned DEFAULT_GLOBAL_EBS_REPLICATION;
+unsigned DEFAULT_LOCAL_REPLICATION;
+
 // read-only per-tier metadata
 unordered_map<unsigned, tier_data> tier_data_map;
 
@@ -40,7 +48,7 @@ void run(unsigned thread_id) {
   unordered_map<string, key_info> placement;
 
   // warm up for benchmark
-  warmup(placement);
+  //warmup(placement);
     
   if (thread_id == 0) {
     // read the YAML conf
@@ -167,7 +175,7 @@ void run(unsigned thread_id) {
             }
 
             // tell all worker threads about the message
-            for (unsigned tid = 1; tid < PROXY_THREAD_NUM; tid++) {
+            for (unsigned tid = 1; tid < ROUTING_THREAD_NUM; tid++) {
               zmq_util::send_string(message, &pushers[routing_thread_t(ip, tid).get_notify_connect_addr()]);
             }
           }
@@ -182,7 +190,7 @@ void run(unsigned thread_id) {
 
         if (thread_id == 0) {
           // tell all worker threads about the message
-          for (unsigned tid = 1; tid < PROXY_THREAD_NUM; tid++) {
+          for (unsigned tid = 1; tid < ROUTING_THREAD_NUM; tid++) {
             zmq_util::send_string(message, &pushers[routing_thread_t(ip, tid).get_notify_connect_addr()]);
           }
         }
@@ -273,7 +281,7 @@ void run(unsigned thread_id) {
 
       if (thread_id == 0) {
         // tell all worker threads about the replication factor change
-        for (unsigned tid = 1; tid < PROXY_THREAD_NUM; tid++) {
+        for (unsigned tid = 1; tid < ROUTING_THREAD_NUM; tid++) {
           zmq_util::send_string(serialized_req, &pushers[routing_thread_t(ip, tid).get_replication_factor_change_connect_addr()]);
         }
       }
@@ -351,12 +359,22 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
+  YAML::Node conf_thread = YAML::LoadFile("conf/config.yml")["thread"];
+  MEMORY_THREAD_NUM = conf_thread["memory"].as<int>();
+  EBS_THREAD_NUM = conf_thread["ebs"].as<int>();
+  ROUTING_THREAD_NUM = conf_thread["routing"].as<int>();
+
+  YAML::Node conf_replication = YAML::LoadFile("conf/config.yml")["replication"];
+  DEFAULT_GLOBAL_MEMORY_REPLICATION = conf_replication["memory"].as<int>();
+  DEFAULT_GLOBAL_EBS_REPLICATION = conf_replication["ebs"].as<int>();
+  DEFAULT_LOCAL_REPLICATION = conf_replication["local"].as<int>();
+
   tier_data_map[1] = tier_data(MEMORY_THREAD_NUM, DEFAULT_GLOBAL_MEMORY_REPLICATION, MEM_NODE_CAPACITY);
   tier_data_map[2] = tier_data(EBS_THREAD_NUM, DEFAULT_GLOBAL_EBS_REPLICATION, EBS_NODE_CAPACITY);
 
   vector<thread> routing_worker_threads;
 
-  for (unsigned thread_id = 1; thread_id < PROXY_THREAD_NUM; thread_id++) {
+  for (unsigned thread_id = 1; thread_id < ROUTING_THREAD_NUM; thread_id++) {
     routing_worker_threads.push_back(thread(run, thread_id));
   }
 

--- a/src/bedrock/server.cpp
+++ b/src/bedrock/server.cpp
@@ -25,14 +25,15 @@
 // TODO: Everything that's currently writing to cout and cerr should be replaced with a logfile.
 using namespace std;
 
+// define server report threshold (in second)
+const unsigned SERVER_REPORT_THRESHOLD = 15;
+// define server's key monitoring threshold (in second)
+const unsigned KEY_MONITORING_THRESHOLD = 60;
+// define the threshold for retry rep factor query for gossip handling (in second)
+const unsigned RETRY_THRESHOLD = 10;
+
 unsigned SELF_TIER_ID;
 
-unsigned MEMORY_THREAD_NUM;
-unsigned EBS_THREAD_NUM;
-
-unsigned DEFAULT_GLOBAL_MEMORY_REPLICATION;
-unsigned DEFAULT_GLOBAL_EBS_REPLICATION;
-unsigned DEFAULT_LOCAL_REPLICATION;
 // number of worker threads
 unsigned THREAD_NUM;
 
@@ -1151,14 +1152,13 @@ int main(int argc, char* argv[]) {
   // populate metadata
   SELF_TIER_ID = atoi(getenv("SERVER_TYPE"));
 
-  YAML::Node conf_thread = YAML::LoadFile("conf/config.yml")["thread"];
-  MEMORY_THREAD_NUM = conf_thread["memory"].as<int>();
-  EBS_THREAD_NUM = conf_thread["ebs"].as<int>();
+  YAML::Node conf = YAML::LoadFile("conf/config.yml");
+  MEMORY_THREAD_NUM = conf["thread"]["memory"].as<int>();
+  EBS_THREAD_NUM = conf["thread"]["ebs"].as<int>();
 
-  YAML::Node conf_replication = YAML::LoadFile("conf/config.yml")["replication"];
-  DEFAULT_GLOBAL_MEMORY_REPLICATION = conf_replication["memory"].as<int>();
-  DEFAULT_GLOBAL_EBS_REPLICATION = conf_replication["ebs"].as<int>();
-  DEFAULT_LOCAL_REPLICATION = conf_replication["local"].as<int>();
+  DEFAULT_GLOBAL_MEMORY_REPLICATION = conf["replication"]["memory"].as<int>();
+  DEFAULT_GLOBAL_EBS_REPLICATION = conf["replication"]["ebs"].as<int>();
+  DEFAULT_LOCAL_REPLICATION = conf["replication"]["local"].as<int>();
 
   tier_data_map[1] = tier_data(MEMORY_THREAD_NUM, DEFAULT_GLOBAL_MEMORY_REPLICATION, MEM_NODE_CAPACITY);
   tier_data_map[2] = tier_data(EBS_THREAD_NUM, DEFAULT_GLOBAL_EBS_REPLICATION, EBS_NODE_CAPACITY);

--- a/src/bedrock/server.cpp
+++ b/src/bedrock/server.cpp
@@ -27,6 +27,12 @@ using namespace std;
 
 unsigned SELF_TIER_ID;
 
+unsigned MEMORY_THREAD_NUM;
+unsigned EBS_THREAD_NUM;
+
+unsigned DEFAULT_GLOBAL_MEMORY_REPLICATION;
+unsigned DEFAULT_GLOBAL_EBS_REPLICATION;
+unsigned DEFAULT_LOCAL_REPLICATION;
 // number of worker threads
 unsigned THREAD_NUM;
 
@@ -1144,6 +1150,15 @@ int main(int argc, char* argv[]) {
 
   // populate metadata
   SELF_TIER_ID = atoi(getenv("SERVER_TYPE"));
+
+  YAML::Node conf_thread = YAML::LoadFile("conf/config.yml")["thread"];
+  MEMORY_THREAD_NUM = conf_thread["memory"].as<int>();
+  EBS_THREAD_NUM = conf_thread["ebs"].as<int>();
+
+  YAML::Node conf_replication = YAML::LoadFile("conf/config.yml")["replication"];
+  DEFAULT_GLOBAL_MEMORY_REPLICATION = conf_replication["memory"].as<int>();
+  DEFAULT_GLOBAL_EBS_REPLICATION = conf_replication["ebs"].as<int>();
+  DEFAULT_LOCAL_REPLICATION = conf_replication["local"].as<int>();
 
   tier_data_map[1] = tier_data(MEMORY_THREAD_NUM, DEFAULT_GLOBAL_MEMORY_REPLICATION, MEM_NODE_CAPACITY);
   tier_data_map[2] = tier_data(EBS_THREAD_NUM, DEFAULT_GLOBAL_EBS_REPLICATION, EBS_NODE_CAPACITY);

--- a/src/bedrock/user.cpp
+++ b/src/bedrock/user.cpp
@@ -16,8 +16,6 @@
 
 using namespace std;
 
-unsigned ROUTING_THREAD_NUM;
-
 void handle_request(
     string request_line,
     SocketCache& pushers,
@@ -236,7 +234,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  YAML::Node conf = YAML::LoadFile("conf/config.yml")["thread"];
+  YAML::Node conf = YAML::LoadFile("conf/config_user.yml")["thread"];
   ROUTING_THREAD_NUM = conf["routing"].as<int>();
 
   if (argc == 1) {

--- a/src/bedrock/user.cpp
+++ b/src/bedrock/user.cpp
@@ -16,6 +16,8 @@
 
 using namespace std;
 
+unsigned ROUTING_THREAD_NUM;
+
 void handle_request(
     string request_line,
     SocketCache& pushers,
@@ -60,7 +62,7 @@ void handle_request(
   string worker_address;
   if (key_address_cache.find(key) == key_address_cache.end()) {
     // query the routing and update the cache
-    string target_routing_address = get_random_routing_thread(routing_address, seed).get_key_address_connect_addr();
+    string target_routing_address = get_random_routing_thread(routing_address, seed, ROUTING_THREAD_NUM).get_key_address_connect_addr();
     bool succeed;
     auto addresses = get_address_from_routing(ut, key, pushers[target_routing_address], key_address_puller, succeed, ip, thread_id, rid);
     if (succeed) {
@@ -233,6 +235,9 @@ int main(int argc, char* argv[]) {
     cerr << "Filename is optional. Omit the filename to run in interactive mode." << endl;
     return 1;
   }
+
+  YAML::Node conf = YAML::LoadFile("conf/config.yml")["thread"];
+  ROUTING_THREAD_NUM = conf["routing"].as<int>();
 
   if (argc == 1) {
     run(0, ""); 

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -16,7 +16,6 @@
 
 using namespace std;
 
-unsigned ROUTING_THREAD_NUM;
 unsigned BENCHMARK_THREAD_NUM;
 
 double get_base(unsigned N, double skew) {
@@ -459,9 +458,9 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  YAML::Node conf_thread = YAML::LoadFile("conf/config.yml")["thread"];
-  ROUTING_THREAD_NUM = conf_thread["routing"].as<int>();
-  BENCHMARK_THREAD_NUM = conf_thread["benchmark"].as<int>();
+  YAML::Node conf = YAML::LoadFile("conf/config_benchmark.yml")["thread"];
+  ROUTING_THREAD_NUM = conf["routing"].as<int>();
+  BENCHMARK_THREAD_NUM = conf["benchmark"].as<int>();
 
   vector<thread> benchmark_threads;
   for (unsigned thread_id = 1; thread_id < BENCHMARK_THREAD_NUM; thread_id++) {


### PR DESCRIPTION
We can now configure thread numbers and default replication factors at runtime.
I left the virtual thread number (used for better load balancing) and metadata replication factor as compile-time constants.