### PR TITLE
Fix routing response when cluster is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+# project specific
 build
 vendor/gtest/build
+log*.txt
 
 # ignore compiled byte code
 target

--- a/src/bedrock/hash_ring.cpp
+++ b/src/bedrock/hash_ring.cpp
@@ -177,9 +177,13 @@ vector<string> get_address_from_routing(
   key_req.set_request_id(req_id);
   vector<string> result;
 
-  int err_number = 1;
+  int err_number = -1;
 
-  while (err_number == 1) {
+  while (err_number != 0) {
+    if (err_number == 1) {
+      cerr << "No servers have joined the cluster yet. Retrying request." << endl;
+    }
+
     if (count > 0 && count % 5 == 0) {
       cerr << "Pausing for 5 seconds before continuing to query routing layer..." << endl;
       usleep(5000000);
@@ -193,7 +197,6 @@ vector<string> get_address_from_routing(
     if (!succeed) {
       return result;
     } else {
-      cerr << "No servers have joined the cluster yet. Retrying request." << endl;
       err_number = key_response.err_number();
     }
 

--- a/src/bedrock/hash_ring.cpp
+++ b/src/bedrock/hash_ring.cpp
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <string>
 #include <functional>
+#include <unistd.h>
 #include "communication.pb.h"
 #include "zmq/socket_cache.hpp"
 #include "zmq/zmq_util.hpp"
@@ -165,25 +166,46 @@ vector<string> get_address_from_routing(
     unsigned& thread_id,
     unsigned& rid) {
 
+  int count = 0;
+
   communication::Key_Request key_req;
+  communication::Key_Response key_response;
   key_req.set_respond_address(ut.get_key_address_connect_addr());
   key_req.add_keys(key);
 
   string req_id = ip + ":" + to_string(thread_id) + "_" + to_string(rid);
   key_req.set_request_id(req_id);
-  rid += 1;
-
-  // query routing for addresses on the other tier
-  auto key_response = send_request<communication::Key_Request, communication::Key_Response>(key_req, sending_socket, receiving_socket, succeed);
   vector<string> result;
 
-  if (succeed) {
-    for (int j = 0; j < key_response.tuple(0).addresses_size(); j++) {
-      result.push_back(key_response.tuple(0).addresses(j));
+  int err_number = 1;
+
+  while (err_number == 1) {
+    if (count > 0 && count % 5 == 0) {
+      cerr << "Pausing for 5 seconds before continuing to query routing layer..." << endl;
+      usleep(5000000);
     }
+
+    rid += 1;
+
+    // query routing for addresses on the other tier
+    key_response = send_request<communication::Key_Request, communication::Key_Response>(key_req, sending_socket, receiving_socket, succeed);
+
+    if (!succeed) {
+      return result;
+    } else {
+      cerr << "No servers have joined the cluster yet. Retrying request." << endl;
+      err_number = key_response.err_number();
+    }
+
+    count++;
+  }
+
+  for (int j = 0; j < key_response.tuple(0).addresses_size(); j++) {
+    result.push_back(key_response.tuple(0).addresses(j));
   }
 
   return result;
+
 }
 
 RoutingThread get_random_routing_thread(vector<string>& routing_address, unsigned& seed) {

--- a/src/bedrock/routing.cpp
+++ b/src/bedrock/routing.cpp
@@ -262,6 +262,7 @@ void run(unsigned thread_id) {
               }
 
               // send the key address response
+              key_res.set_err_number(0);
               string serialized_key_res;
               key_res.SerializeToString(&serialized_key_res);
               zmq_util::send_string(serialized_key_res, &pushers[it->first]);

--- a/src/bedrock/routing.cpp
+++ b/src/bedrock/routing.cpp
@@ -312,41 +312,57 @@ void run(unsigned thread_id) {
       key_res.set_response_id(key_req.request_id());
       bool succeed;
 
-      for (int i = 0; i < key_req.keys_size(); i++) {
-        // first check memory tier
-        vector<unsigned> tier_ids;
-        tier_ids.push_back(1);
-
-        string key = key_req.keys(i);
-        auto threads = get_responsible_threads(pt.get_replication_factor_connect_addr(), key, false, global_hash_ring_map, local_hash_ring_map, placement, pushers, tier_ids, succeed, seed);
-
-        if (succeed) {
-          if (threads.size() == 0) {
-            // check ebs tier
-            tier_ids.clear();
-            tier_ids.push_back(2);
-            threads = get_responsible_threads(pt.get_replication_factor_connect_addr(), key, false, global_hash_ring_map, local_hash_ring_map, placement, pushers, tier_ids, succeed, seed);
-          }
-
-          communication::Key_Response_Tuple* tp = key_res.add_tuple();
-          tp->set_key(key);
-
-          for (auto it = threads.begin(); it != threads.end(); it++) {
-            tp->add_addresses(it->get_request_pulling_connect_addr());
-          }
-        } else {
-          if (pending_key_request_map.find(key) == pending_key_request_map.end()) {
-            pending_key_request_map[key].first = chrono::system_clock::now();
-          }
-
-          pending_key_request_map[key].second.push_back(pair<string, string>(key_req.respond_address(), key_req.request_id()));
-        }
+      int num_servers = 0;
+      for (auto it = global_hash_ring_map.begin(); it != global_hash_ring_map.end(); ++it) {
+        num_servers += it->second.size();
       }
-      if (key_res.tuple_size() > 0) {
+
+      if (num_servers == 0) {
+        key_res.set_err_number(1);
+
         string serialized_key_res;
         key_res.SerializeToString(&serialized_key_res);
 
         zmq_util::send_string(serialized_key_res, &pushers[key_req.respond_address()]);
+      } else { // if there are servers, attempt to return the correct threads
+        for (int i = 0; i < key_req.keys_size(); i++) {
+          vector<unsigned> tier_ids;
+          tier_ids.push_back(1);
+
+          string key = key_req.keys(i);
+          auto threads = get_responsible_threads(pt.get_replication_factor_connect_addr(), key, false, global_hash_ring_map, local_hash_ring_map, placement, pushers, tier_ids, succeed, seed);
+
+          if (succeed) {
+            if (threads.size() == 0) {
+              // check ebs tier
+              tier_ids.clear();
+              tier_ids.push_back(2);
+              threads = get_responsible_threads(pt.get_replication_factor_connect_addr(), key, false, global_hash_ring_map, local_hash_ring_map, placement, pushers, tier_ids, succeed, seed);
+            }
+
+            communication::Key_Response_Tuple* tp = key_res.add_tuple();
+            tp->set_key(key);
+
+            for (auto it = threads.begin(); it != threads.end(); it++) {
+              tp->add_addresses(it->get_request_pulling_connect_addr());
+            }
+          } else {
+            if (pending_key_request_map.find(key) == pending_key_request_map.end()) {
+              pending_key_request_map[key].first = chrono::system_clock::now();
+            }
+
+            pending_key_request_map[key].second.push_back(pair<string, string>(key_req.respond_address(), key_req.request_id()));
+          }
+        }
+
+        if (key_res.tuple_size() > 0) {
+          key_res.set_err_number(0);
+
+          string serialized_key_res;
+          key_res.SerializeToString(&serialized_key_res);
+
+          zmq_util::send_string(serialized_key_res, &pushers[key_req.respond_address()]);
+        }
       }
     }
   }

--- a/src/bedrock/user.cpp
+++ b/src/bedrock/user.cpp
@@ -67,7 +67,8 @@ void handle_request(
     // query the routing and update the cache
     string target_routing_address = get_random_routing_thread(routing_address, seed).get_key_address_connect_addr();
     bool succeed;
-    auto addresses = get_address_from_routing(ut, key, pushers[target_routing_address], key_address_puller, succeed, ip, thread_id, rid);
+    vector<string> addresses = get_address_from_routing(ut, key, pushers[target_routing_address], key_address_puller, succeed, ip, thread_id, rid);
+
     if (succeed) {
       for (auto it = addresses.begin(); it != addresses.end(); it++) {
         key_address_cache[key].insert(*it);
@@ -82,6 +83,7 @@ void handle_request(
       logger->error("Address cache for key " + key + " has size 0.");
       return;
     }
+
     worker_address = *(next(begin(key_address_cache[key]), rand_r(&seed) % key_address_cache[key].size()));
   }
 

--- a/src/include/communication.proto
+++ b/src/include/communication.proto
@@ -38,8 +38,10 @@ message Key_Response {
     required string key = 1;
     repeated string addresses = 2;
   }
+    
   repeated Tuple tuple = 1;
   optional string response_id = 2;
+  required uint32 err_number = 3;
 }
 
 message Payload {

--- a/tests/simple/test_simple.sh
+++ b/tests/simple/test_simple.sh
@@ -16,17 +16,6 @@ fi
 echo "Starting local server..."
 ./scripts/start_local.sh $BUILD n
 
-sleep 1
-
-# wait until the routing tier has received a join from the server before making
-# a request
-JOIN=`cat log* | grep routing | grep 'Received join' | wc -l`
-while [ $JOIN -eq 0 ]; do
-  JOIN=`cat log* | grep routing | grep 'Received join' | wc -l`
-done
-
-sleep 3
-
 echo "Running tests..."
 ./build/src/bedrock/user tests/simple/input > tmp.out
 


### PR DESCRIPTION
* Routing layer now returns an error code if the cluster is empty.
* User & benchmark nodes (via `get_address_from_routing`) will wait & repeatedly query the routing layer while there are no storage servers.
* Remove brittle log grep-ing from `simple_test.sh`.

Fixes #53.