### PR TITLE
fix monitoring issues

### DIFF
--- a/src/bedrock/kvs/rep_factor_response_handler.cpp
+++ b/src/bedrock/kvs/rep_factor_response_handler.cpp
@@ -47,11 +47,7 @@ void rep_factor_response_handler(
           local.local_replication();
     }
   } else {
-    for (const unsigned& tier_id : kAllTierIds) {
-      placement[key].global_replication_map_[tier_id] =
-          kTierDataMap[tier_id].default_replication_;
-      placement[key].local_replication_map_[tier_id] = kDefaultLocalReplication;
-    }
+    init_replication(placement, key);
   }
 
   bool succeed;

--- a/src/bedrock/kvs/utils.cpp
+++ b/src/bedrock/kvs/utils.cpp
@@ -46,3 +46,25 @@ void process_put(const Key& key, const unsigned long long& timestamp,
     key_size_map[key] = value.size();
   }
 }
+
+bool is_primary_replica(const Key& key, std::unordered_map<Key, KeyInfo>& placement,
+                        std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
+                        std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
+                        ServerThread& st) {
+  if (placement[key].global_replication_map_[kSelfTierId] == 0) {
+    return false;
+  } else if (kSelfTierId == 2 && placement[key].global_replication_map_[1] > 0) {
+    return false;
+  } else {
+    auto global_pos = global_hash_ring_map[kSelfTierId].find(key);
+    if (global_pos != global_hash_ring_map[kSelfTierId].end() &&
+        st.get_ip().compare(global_pos->second.get_ip()) == 0) {
+      auto local_pos = local_hash_ring_map[kSelfTierId].find(key);
+      if (local_pos != local_hash_ring_map[kSelfTierId].end() &&
+         st.get_tid() == local_pos->second.get_tid()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/src/bedrock/monitor/elasticity.cpp
+++ b/src/bedrock/monitor/elasticity.cpp
@@ -14,10 +14,9 @@ void add_node(std::shared_ptr<spdlog::logger> logger, std::string tier,
 void remove_node(std::shared_ptr<spdlog::logger> logger, ServerThread& node,
                  std::string tier, bool& removing_flag, SocketCache& pushers,
                  std::unordered_map<Address, unsigned>& departing_node_map,
-                 MonitoringThread& mt,
-                 std::unordered_map<unsigned, TierData>& tier_data_map) {
+                 MonitoringThread& mt) {
   auto connection_addr = node.get_self_depart_connect_addr();
-  departing_node_map[node.get_ip()] = tier_data_map[1].thread_number_;
+  departing_node_map[node.get_ip()] = kTierDataMap[1].thread_number_;
   auto ack_addr = mt.get_depart_done_connect_addr();
   logger->info("Removing {} node {}.", tier, node.get_ip());
   zmq_util::send_string(ack_addr, &pushers[connection_addr]);

--- a/src/bedrock/monitor/feedback_handler.cpp
+++ b/src/bedrock/monitor/feedback_handler.cpp
@@ -4,7 +4,7 @@ void feedback_handler(
     zmq::socket_t* feedback_puller,
     std::unordered_map<std::string, double>& user_latency,
     std::unordered_map<std::string, double>& user_throughput,
-    std::unordered_map<Key, std::pair<double, unsigned>>& bump_factor_map) {
+    std::unordered_map<Key, std::pair<double, unsigned>>& latency_miss_ratio_map) {
   std::string serialized_feedback = zmq_util::recv_string(feedback_puller);
   communication::Feedback fb;
   fb.ParseFromString(serialized_feedback);
@@ -21,14 +21,14 @@ void feedback_handler(
       Key key = key_latency_pair.key();
       double observed_key_latency = key_latency_pair.latency();
 
-      if (bump_factor_map.find(key) == bump_factor_map.end()) {
-        bump_factor_map[key].first = observed_key_latency / kSloWorst;
-        bump_factor_map[key].second = 1;
+      if (latency_miss_ratio_map.find(key) == latency_miss_ratio_map.end()) {
+        latency_miss_ratio_map[key].first = observed_key_latency / kSloWorst;
+        latency_miss_ratio_map[key].second = 1;
       } else {
-        bump_factor_map[key].first =
-            (bump_factor_map[key].first * bump_factor_map[key].second + observed_key_latency / kSloWorst) /
-            (bump_factor_map[key].second + 1);
-        bump_factor_map[key].second += 1;
+        latency_miss_ratio_map[key].first =
+            (latency_miss_ratio_map[key].first * latency_miss_ratio_map[key].second + observed_key_latency / kSloWorst) /
+            (latency_miss_ratio_map[key].second + 1);
+        latency_miss_ratio_map[key].second += 1;
       }
     }
   }

--- a/src/bedrock/monitor/feedback_handler.cpp
+++ b/src/bedrock/monitor/feedback_handler.cpp
@@ -4,7 +4,7 @@ void feedback_handler(
     zmq::socket_t* feedback_puller,
     std::unordered_map<std::string, double>& user_latency,
     std::unordered_map<std::string, double>& user_throughput,
-    std::unordered_map<Key, std::pair<double, unsigned>>& rep_factor_map) {
+    std::unordered_map<Key, std::pair<double, unsigned>>& bump_factor_map) {
   std::string serialized_feedback = zmq_util::recv_string(feedback_puller);
   communication::Feedback fb;
   fb.ParseFromString(serialized_feedback);
@@ -17,18 +17,18 @@ void feedback_handler(
     user_throughput[fb.uid()] = fb.throughput();
 
     // collect replication factor adjustment factors
-    for (const auto& rep : fb.rep()) {
-      Key key = rep.key();
-      double factor = rep.factor();
+    for (const auto& key_latency_pair : fb.key_latency()) {
+      Key key = key_latency_pair.key();
+      double observed_key_latency = key_latency_pair.latency();
 
-      if (rep_factor_map.find(key) == rep_factor_map.end()) {
-        rep_factor_map[key].first = factor;
-        rep_factor_map[key].second = 1;
+      if (bump_factor_map.find(key) == bump_factor_map.end()) {
+        bump_factor_map[key].first = observed_key_latency / kSloWorst;
+        bump_factor_map[key].second = 1;
       } else {
-        rep_factor_map[key].first =
-            (rep_factor_map[key].first * rep_factor_map[key].second + factor) /
-            (rep_factor_map[key].second + 1);
-        rep_factor_map[key].second += 1;
+        bump_factor_map[key].first =
+            (bump_factor_map[key].first * bump_factor_map[key].second + observed_key_latency / kSloWorst) /
+            (bump_factor_map[key].second + 1);
+        bump_factor_map[key].second += 1;
       }
     }
   }

--- a/src/bedrock/monitor/monitoring.cpp
+++ b/src/bedrock/monitor/monitoring.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
   // keep track of user throughput info
   std::unordered_map<std::string, double> user_throughput;
   // used for adjusting the replication factors based on feedback from the user
-  std::unordered_map<Key, std::pair<double, unsigned>> bump_factor_map;
+  std::unordered_map<Key, std::pair<double, unsigned>> latency_miss_ratio_map;
 
   std::vector<Address> routing_address;
 
@@ -162,7 +162,7 @@ int main(int argc, char *argv[]) {
 
     if (pollitems[2].revents & ZMQ_POLLIN) {
       feedback_handler(&feedback_puller, user_latency, user_throughput,
-                       bump_factor_map);
+                       latency_miss_ratio_map);
     }
 
     report_end = std::chrono::system_clock::now();
@@ -188,7 +188,7 @@ int main(int argc, char *argv[]) {
 
       user_latency.clear();
       user_throughput.clear();
-      bump_factor_map.clear();
+      latency_miss_ratio_map.clear();
 
       // collect internal statistics
       collect_internal_stats(global_hash_ring_map, local_hash_ring_map, pushers,
@@ -233,7 +233,7 @@ int main(int argc, char *argv[]) {
                  removing_memory_node, management_address, placement,
                  key_access_summary, mt, departing_node_map,
                  pushers, response_puller, routing_address, rid,
-                 bump_factor_map);
+                 latency_miss_ratio_map);
 
       report_start = std::chrono::system_clock::now();
     }

--- a/src/bedrock/monitor/monitoring.cpp
+++ b/src/bedrock/monitor/monitoring.cpp
@@ -12,7 +12,7 @@ unsigned kDefaultLocalReplication;
 unsigned kMinimumReplicaNumber;
 
 // read-only per-tier metadata
-std::unordered_map<unsigned, TierData> tier_data_map;
+std::unordered_map<unsigned, TierData> kTierDataMap;
 
 int main(int argc, char *argv[]) {
   auto logger = spdlog::basic_logger_mt("monitoring_logger", "log.txt", true);
@@ -39,9 +39,9 @@ int main(int argc, char *argv[]) {
   kDefaultLocalReplication = replication["local"].as<unsigned>();
   kMinimumReplicaNumber = replication["minimum"].as<unsigned>();
 
-  tier_data_map[1] = TierData(
+  kTierDataMap[1] = TierData(
       kMemoryThreadCount, kDefaultGlobalMemoryReplication, kMemoryNodeCapacity);
-  tier_data_map[2] =
+  kTierDataMap[2] =
       TierData(kEbsThreadCount, kDefaultGlobalEbsReplication, kEbsNodeCapacity);
 
   // initialize hash ring maps
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
   std::unordered_map<unsigned, LocalHashRing> local_hash_ring_map;
 
   // form local hash rings
-  for (const auto &tier_pair : tier_data_map) {
+  for (const auto &tier_pair : kTierDataMap) {
     for (unsigned tid = 0; tid < tier_pair.second.thread_number_; tid++) {
       insert_to_hash_ring<LocalHashRing>(local_hash_ring_map[tier_pair.first],
                                          ip, tid);
@@ -68,6 +68,8 @@ int main(int argc, char *argv[]) {
       key_access_frequency;
   // keep track of the keys' access summary
   std::unordered_map<Key, unsigned> key_access_summary;
+  // keep track of the size of each key-value pair
+  std::unordered_map<Key, unsigned> key_size;
   // keep track of memory tier storage consumption
   StorageStat memory_tier_storage;
   // keep track of ebs tier storage consumption
@@ -87,7 +89,7 @@ int main(int argc, char *argv[]) {
   // keep track of user throughput info
   std::unordered_map<std::string, double> user_throughput;
   // used for adjusting the replication factors based on feedback from the user
-  std::unordered_map<Key, std::pair<double, unsigned>> rep_factor_map;
+  std::unordered_map<Key, std::pair<double, unsigned>> bump_factor_map;
 
   std::vector<Address> routing_address;
 
@@ -160,7 +162,7 @@ int main(int argc, char *argv[]) {
 
     if (pollitems[2].revents & ZMQ_POLLIN) {
       feedback_handler(&feedback_puller, user_latency, user_throughput,
-                       rep_factor_map);
+                       bump_factor_map);
     }
 
     report_end = std::chrono::system_clock::now();
@@ -186,44 +188,52 @@ int main(int argc, char *argv[]) {
 
       user_latency.clear();
       user_throughput.clear();
-      rep_factor_map.clear();
+      bump_factor_map.clear();
 
       // collect internal statistics
       collect_internal_stats(global_hash_ring_map, local_hash_ring_map, pushers,
                              mt, response_puller, logger, rid,
-                             key_access_frequency, memory_tier_storage,
+                             key_access_frequency, key_size, memory_tier_storage,
                              ebs_tier_storage, memory_tier_occupancy,
                              ebs_tier_occupancy, memory_tier_access,
-                             ebs_tier_access, tier_data_map);
+                             ebs_tier_access);
 
       // compute summary statistics
       compute_summary_stats(key_access_frequency, memory_tier_storage,
                             ebs_tier_storage, memory_tier_occupancy,
                             ebs_tier_occupancy, memory_tier_access,
                             ebs_tier_access, key_access_summary, ss, logger,
-                            server_monitoring_epoch, tier_data_map);
+                            server_monitoring_epoch);
 
       // collect external statistics
       collect_external_stats(user_latency, user_throughput, ss, logger);
+
+      // initialize replication factor for new keys
+      for (const auto& key_access_pair : key_access_summary) {
+        Key key = key_access_pair.first;
+        if (!is_metadata(key) && placement.find(key) == placement.end()) {
+          init_replication(placement, key);
+        }
+      }
 
       // execute policies
       storage_policy(logger, global_hash_ring_map, grace_start, ss,
                      memory_node_number, ebs_node_number, adding_memory_node,
                      adding_ebs_node, removing_ebs_node, management_address, mt,
-                     tier_data_map, departing_node_map, pushers);
+                     departing_node_map, pushers);
 
       movement_policy(logger, global_hash_ring_map, local_hash_ring_map,
                       grace_start, ss, memory_node_number, ebs_node_number,
                       adding_memory_node, adding_ebs_node, management_address,
-                      placement, key_access_summary, mt, tier_data_map, pushers,
+                      placement, key_access_summary, key_size, mt, pushers,
                       response_puller, routing_address, rid);
 
       slo_policy(logger, global_hash_ring_map, local_hash_ring_map, grace_start,
                  ss, memory_node_number, adding_memory_node,
                  removing_memory_node, management_address, placement,
-                 key_access_summary, mt, tier_data_map, departing_node_map,
+                 key_access_summary, mt, departing_node_map,
                  pushers, response_puller, routing_address, rid,
-                 rep_factor_map);
+                 bump_factor_map);
 
       report_start = std::chrono::system_clock::now();
     }

--- a/src/bedrock/monitor/slo_policy.cpp
+++ b/src/bedrock/monitor/slo_policy.cpp
@@ -13,7 +13,7 @@ void slo_policy(
     std::unordered_map<Address, unsigned>& departing_node_map,
     SocketCache& pushers, zmq::socket_t& response_puller,
     std::vector<Address>& routing_address, unsigned& rid,
-    std::unordered_map<Key, std::pair<double, unsigned>>& bump_factor_map) {
+    std::unordered_map<Key, std::pair<double, unsigned>>& latency_miss_ratio_map) {
   // check latency to trigger elasticity or selective replication
   std::unordered_map<Key, KeyInfo> requests;
   if (ss.avg_latency > kSloWorst && adding_memory_node == 0) {
@@ -42,12 +42,12 @@ void slo_policy(
 
         if (!is_metadata(key) &&
             total_access > ss.key_access_mean + ss.key_access_std &&
-            bump_factor_map.find(key) != bump_factor_map.end()) {
+            latency_miss_ratio_map.find(key) != latency_miss_ratio_map.end()) {
           logger->info("Key {} accessed {} times (threshold is {}).", key,
                        total_access, ss.key_access_mean + ss.key_access_std);
           unsigned target_rep_factor =
               placement[key].global_replication_map_[1] *
-              bump_factor_map[key].first;
+              latency_miss_ratio_map[key].first;
 
           if (target_rep_factor == placement[key].global_replication_map_[1]) {
             target_rep_factor += 1;

--- a/src/bedrock/monitor/slo_policy.cpp
+++ b/src/bedrock/monitor/slo_policy.cpp
@@ -10,11 +10,10 @@ void slo_policy(
     unsigned& adding_memory_node, bool& removing_memory_node,
     Address management_address, std::unordered_map<Key, KeyInfo>& placement,
     std::unordered_map<Key, unsigned>& key_access_summary, MonitoringThread& mt,
-    std::unordered_map<unsigned, TierData>& tier_data_map,
     std::unordered_map<Address, unsigned>& departing_node_map,
     SocketCache& pushers, zmq::socket_t& response_puller,
     std::vector<Address>& routing_address, unsigned& rid,
-    std::unordered_map<Key, std::pair<double, unsigned>>& rep_factor_map) {
+    std::unordered_map<Key, std::pair<double, unsigned>>& bump_factor_map) {
   // check latency to trigger elasticity or selective replication
   std::unordered_map<Key, KeyInfo> requests;
   if (ss.avg_latency > kSloWorst && adding_memory_node == 0) {
@@ -43,12 +42,12 @@ void slo_policy(
 
         if (!is_metadata(key) &&
             total_access > ss.key_access_mean + ss.key_access_std &&
-            rep_factor_map.find(key) != rep_factor_map.end()) {
+            bump_factor_map.find(key) != bump_factor_map.end()) {
           logger->info("Key {} accessed {} times (threshold is {}).", key,
                        total_access, ss.key_access_mean + ss.key_access_std);
           unsigned target_rep_factor =
               placement[key].global_replication_map_[1] *
-              rep_factor_map[key].first;
+              bump_factor_map[key].first;
 
           if (target_rep_factor == placement[key].global_replication_map_[1]) {
             target_rep_factor += 1;
@@ -125,7 +124,7 @@ void slo_policy(
 
       ServerThread node = ServerThread(ss.min_occupancy_memory_ip, 0);
       remove_node(logger, node, "memory", removing_memory_node, pushers,
-                  departing_node_map, mt, tier_data_map);
+                  departing_node_map, mt);
     }
   }
 }

--- a/src/bedrock/monitor/stats_helpers.cpp
+++ b/src/bedrock/monitor/stats_helpers.cpp
@@ -8,10 +8,10 @@ void collect_internal_stats(
     std::shared_ptr<spdlog::logger> logger, unsigned& rid,
     std::unordered_map<Key, std::unordered_map<Address, unsigned>>&
         key_access_frequency,
+    std::unordered_map<Key, unsigned>& key_size,
     StorageStat& memory_tier_storage, StorageStat& ebs_tier_storage,
     OccupancyStat& memory_tier_occupancy, OccupancyStat& ebs_tier_occupancy,
-    AccessStat& memory_tier_access, AccessStat& ebs_tier_access,
-    std::unordered_map<unsigned, TierData>& tier_data_map) {
+    AccessStat& memory_tier_access, AccessStat& ebs_tier_access) {
   std::unordered_map<Address, communication::Request> addr_request_map;
 
   for (const auto& global_pair : global_hash_ring_map) {
@@ -22,7 +22,7 @@ void collect_internal_stats(
     for (const auto hash_pair : hash_ring) {
       Address server_ip = hash_pair.second.get_ip();
       if (observed_ip.find(server_ip) == observed_ip.end()) {
-        for (unsigned i = 0; i < tier_data_map[tier_id].thread_number_; i++) {
+        for (unsigned i = 0; i < kTierDataMap[tier_id].thread_number_; i++) {
           Key key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
                     std::to_string(i) + "_" + std::to_string(tier_id) + "_stat";
           prepare_metadata_get_request(key, global_hash_ring_map[1],
@@ -31,6 +31,11 @@ void collect_internal_stats(
 
           key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
                 std::to_string(i) + "_" + std::to_string(tier_id) + "_access";
+          prepare_metadata_get_request(key, global_hash_ring_map[1],
+                                       local_hash_ring_map[1], addr_request_map,
+                                       mt, rid);
+          key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
+                std::to_string(i) + "_" + std::to_string(tier_id) + "_size";
           prepare_metadata_get_request(key, global_hash_ring_map[1],
                                        local_hash_ring_map[1], addr_request_map,
                                        mt, rid);
@@ -84,6 +89,14 @@ void collect_internal_stats(
               key_access_frequency[key][ip + ":" + std::to_string(tid)] =
                   access_tuple.access();
             }
+          } else if (metadata_type == "size") {
+            // deserialized the size
+            communication::Key_Size key_size_msg;
+            key_size_msg.ParseFromString(tuple.value());
+
+            for (const auto& key_size_tuple : key_size_msg.tuple()) {
+              key_size[key_size_tuple.key()] = key_size_tuple.size();
+            }
           }
         } else if (tuple.err_number() == 1) {
           logger->error("Key {} doesn't exist.", tuple.key());
@@ -106,8 +119,7 @@ void compute_summary_stats(
     OccupancyStat& memory_tier_occupancy, OccupancyStat& ebs_tier_occupancy,
     AccessStat& memory_tier_access, AccessStat& ebs_tier_access,
     std::unordered_map<Key, unsigned>& key_access_summary, SummaryStats& ss,
-    std::shared_ptr<spdlog::logger> logger, unsigned& server_monitoring_epoch,
-    std::unordered_map<unsigned, TierData>& tier_data_map) {
+    std::shared_ptr<spdlog::logger> logger, unsigned& server_monitoring_epoch) {
   // compute key access summary
   unsigned cnt = 0;
   double mean = 0;
@@ -169,7 +181,7 @@ void compute_summary_stats(
     }
 
     double percentage = (double)total_thread_consumption /
-                        (double)tier_data_map[1].node_capacity_;
+                        (double)kTierDataMap[1].node_capacity_;
     logger->info("Memory node {} storage consumption is {}.",
                  memory_storage.first, percentage);
 
@@ -189,7 +201,7 @@ void compute_summary_stats(
     }
 
     double percentage = (double)total_thread_consumption /
-                        (double)tier_data_map[2].node_capacity_;
+                        (double)kTierDataMap[2].node_capacity_;
     logger->info("EBS node {} storage consumption is {}.", ebs_storage.first,
                  percentage);
 
@@ -202,7 +214,7 @@ void compute_summary_stats(
   if (m_count != 0) {
     ss.avg_memory_consumption_percentage =
         (double)ss.total_memory_consumption /
-        ((double)m_count * tier_data_map[1].node_capacity_);
+        ((double)m_count * kTierDataMap[1].node_capacity_);
     logger->info("Average memory node consumption is {}.",
                  ss.avg_memory_consumption_percentage);
     logger->info("Max memory node consumption is {}.",
@@ -212,7 +224,7 @@ void compute_summary_stats(
   if (e_count != 0) {
     ss.avg_ebs_consumption_percentage =
         (double)ss.total_ebs_consumption /
-        ((double)e_count * tier_data_map[2].node_capacity_);
+        ((double)e_count * kTierDataMap[2].node_capacity_);
     logger->info("Average EBS node consumption is {}.",
                  ss.avg_ebs_consumption_percentage);
     logger->info("Max EBS node consumption is {}.",
@@ -221,10 +233,10 @@ void compute_summary_stats(
 
   ss.required_memory_node =
       ceil(ss.total_memory_consumption /
-           (kMaxMemoryNodeConsumption * tier_data_map[1].node_capacity_));
+           (kMaxMemoryNodeConsumption * kTierDataMap[1].node_capacity_));
   ss.required_ebs_node =
       ceil(ss.total_ebs_consumption /
-           (kMaxEbsNodeConsumption * tier_data_map[2].node_capacity_));
+           (kMaxEbsNodeConsumption * kTierDataMap[2].node_capacity_));
 
   logger->info("The system requires {} new memory nodes.",
                ss.required_memory_node);

--- a/src/bedrock/monitor/storage_policy.cpp
+++ b/src/bedrock/monitor/storage_policy.cpp
@@ -8,7 +8,6 @@ void storage_policy(
     SummaryStats& ss, unsigned& memory_node_number, unsigned& ebs_node_number,
     unsigned& adding_memory_node, unsigned& adding_ebs_node,
     bool& removing_ebs_node, Address management_address, MonitoringThread& mt,
-    std::unordered_map<unsigned, TierData>& tier_data_map,
     std::unordered_map<Address, unsigned>& departing_node_map,
     SocketCache& pushers) {
   // check storage consumption and trigger elasticity if necessary
@@ -46,7 +45,7 @@ void storage_policy(
                        rand() % global_hash_ring_map[2].size())
                       ->second;
       remove_node(logger, node, "ebs", removing_ebs_node, pushers,
-                  departing_node_map, mt, tier_data_map);
+                  departing_node_map, mt);
     }
   }
 }

--- a/src/bedrock/route/replication_response_handler.cpp
+++ b/src/bedrock/route/replication_response_handler.cpp
@@ -39,11 +39,7 @@ void replication_response_handler(
                                      global_hash_ring_map[1],
                                      local_hash_ring_map[1], pushers, seed);
   } else {
-    for (const unsigned& tier_id : kAllTierIds) {
-      placement[key].global_replication_map_[tier_id] =
-          kTierDataMap[tier_id].default_replication_;
-      placement[key].local_replication_map_[tier_id] = kDefaultLocalReplication;
-    }
+    init_replication(placement, key);
   }
 
   if (response.tuple(0).err_number() != 2) {

--- a/src/include/communication.proto
+++ b/src/include/communication.proto
@@ -105,14 +105,22 @@ message Address {
 }
 
 message Feedback {
-  message Rep {
+  message Key_Latency {
     required string key = 1;
-    required double factor = 2;
+    required double latency = 2;
   }
   required string uid = 1;
   optional double latency = 2;
   optional bool finish = 3;
   optional double throughput = 4;
   optional bool warmup = 5;
-  repeated Rep rep = 6;
+  repeated Key_Latency key_latency = 6;
+}
+
+message Key_Size {
+  message Tuple {
+    required string key = 1;
+    required uint32 size = 2;
+  }
+  repeated Tuple tuple = 1;
 }

--- a/src/include/hash_ring.hpp
+++ b/src/include/hash_ring.hpp
@@ -78,4 +78,12 @@ inline void warmup_placement_to_defaults(
   }
 }
 
+inline void init_replication(std::unordered_map<Key, KeyInfo>& placement, const Key& key) {
+  for (const unsigned& tier_id : kAllTierIds) {
+    placement[key].global_replication_map_[tier_id] =
+        kTierDataMap[tier_id].default_replication_;
+    placement[key].local_replication_map_[tier_id] = kDefaultLocalReplication;
+  }
+}
+
 #endif

--- a/src/include/kvs/kvs_handlers.hpp
+++ b/src/include/kvs/kvs_handlers.hpp
@@ -92,4 +92,9 @@ std::pair<ReadCommittedPairLattice<std::string>, unsigned> process_get(
 void process_put(const Key& key, const unsigned long long& timestamp,
                  const std::string& value, Serializer* serializer,
                  std::unordered_map<std::string, unsigned>& key_size_map);
+
+bool is_primary_replica(const Key& key, std::unordered_map<Key, KeyInfo>& placement,
+                        std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
+                        std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
+                        ServerThread& st);
 #endif

--- a/src/include/monitor/monitoring_handlers.hpp
+++ b/src/include/monitor/monitoring_handlers.hpp
@@ -26,6 +26,6 @@ void feedback_handler(
     zmq::socket_t* feedback_puller,
     std::unordered_map<std::string, double>& user_latency,
     std::unordered_map<std::string, double>& user_throughput,
-    std::unordered_map<Key, std::pair<double, unsigned>>& rep_factor_map);
+    std::unordered_map<Key, std::pair<double, unsigned>>& latency_miss_ratio_map);
 
 #endif

--- a/src/include/monitor/monitoring_utils.hpp
+++ b/src/include/monitor/monitoring_utils.hpp
@@ -104,10 +104,10 @@ void collect_internal_stats(
     std::shared_ptr<spdlog::logger> logger, unsigned& rid,
     std::unordered_map<Key, std::unordered_map<Address, unsigned>>&
         key_access_frequency,
+    std::unordered_map<Key, unsigned>& key_size,
     StorageStat& memory_tier_storage, StorageStat& ebs_tier_storage,
     OccupancyStat& memory_tier_occupancy, OccupancyStat& ebs_tier_occupancy,
-    AccessStat& memory_tier_access, AccessStat& ebs_tier_access,
-    std::unordered_map<unsigned, TierData>& tier_data_map);
+    AccessStat& memory_tier_access, AccessStat& ebs_tier_access);
 
 void compute_summary_stats(
     std::unordered_map<Key, std::unordered_map<Address, unsigned>>&
@@ -116,8 +116,7 @@ void compute_summary_stats(
     OccupancyStat& memory_tier_occupancy, OccupancyStat& ebs_tier_occupancy,
     AccessStat& memory_tier_access, AccessStat& ebs_tier_access,
     std::unordered_map<Key, unsigned>& key_access_summary, SummaryStats& ss,
-    std::shared_ptr<spdlog::logger> logger, unsigned& server_monitoring_epoch,
-    std::unordered_map<unsigned, TierData>& tier_data_map);
+    std::shared_ptr<spdlog::logger> logger, unsigned& server_monitoring_epoch);
 
 void collect_external_stats(
     std::unordered_map<std::string, double>& user_latency,
@@ -149,7 +148,6 @@ void add_node(std::shared_ptr<spdlog::logger> logger, std::string tier,
 void remove_node(std::shared_ptr<spdlog::logger> logger, ServerThread& node,
                  std::string tier, bool& removing_flag, SocketCache& pushers,
                  std::unordered_map<Address, unsigned>& departing_node_map,
-                 MonitoringThread& mt,
-                 std::unordered_map<unsigned, TierData>& tier_data_map);
+                 MonitoringThread& mt);
 
 #endif

--- a/src/include/monitor/policies.hpp
+++ b/src/include/monitor/policies.hpp
@@ -40,6 +40,6 @@ void slo_policy(
     std::unordered_map<Address, unsigned>& departing_node_map,
     SocketCache& pushers, zmq::socket_t& response_puller,
     std::vector<Address>& routing_address, unsigned& rid,
-    std::unordered_map<Key, std::pair<double, unsigned>>& bump_factor_map);
+    std::unordered_map<Key, std::pair<double, unsigned>>& latency_miss_ratio_map);
 
 #endif

--- a/src/include/monitor/policies.hpp
+++ b/src/include/monitor/policies.hpp
@@ -11,7 +11,6 @@ void storage_policy(
     SummaryStats& ss, unsigned& memory_node_number, unsigned& ebs_node_number,
     unsigned& adding_memory_node, unsigned& adding_ebs_node,
     bool& removing_ebs_node, Address management_address, MonitoringThread& mt,
-    std::unordered_map<unsigned, TierData>& tier_data_map,
     std::unordered_map<Address, unsigned>& departing_node_map,
     SocketCache& pushers);
 
@@ -23,8 +22,9 @@ void movement_policy(
     SummaryStats& ss, unsigned& memory_node_number, unsigned& ebs_node_number,
     unsigned& adding_memory_node, unsigned& adding_ebs_node,
     Address management_address, std::unordered_map<Key, KeyInfo>& placement,
-    std::unordered_map<Key, unsigned>& key_access_summary, MonitoringThread& mt,
-    std::unordered_map<unsigned, TierData>& tier_data_map, SocketCache& pushers,
+    std::unordered_map<Key, unsigned>& key_access_summary,
+    std::unordered_map<Key, unsigned>& key_size, MonitoringThread& mt,
+    SocketCache& pushers,
     zmq::socket_t& response_puller, std::vector<Address>& routing_address,
     unsigned& rid);
 
@@ -37,10 +37,9 @@ void slo_policy(
     unsigned& adding_memory_node, bool& removing_memory_node,
     Address management_address, std::unordered_map<Key, KeyInfo>& placement,
     std::unordered_map<Key, unsigned>& key_access_summary, MonitoringThread& mt,
-    std::unordered_map<unsigned, TierData>& tier_data_map,
     std::unordered_map<Address, unsigned>& departing_node_map,
     SocketCache& pushers, zmq::socket_t& response_puller,
     std::vector<Address>& routing_address, unsigned& rid,
-    std::unordered_map<Key, std::pair<double, unsigned>>& rep_factor_map);
+    std::unordered_map<Key, std::pair<double, unsigned>>& bump_factor_map);
 
 #endif


### PR DESCRIPTION
Fix issues #70 #76 #77 
1. If the key's replication factor is not cached on the monitoring thread, set it to default (we can do it now because monitoring is currently done single-threaded and it is the only entity that can ever issue a replication factor change).
2. Instead of relying on `kValueSize`, servers periodically stores key size info to Anna, and the monitoring thread pulls this info to determine how many keys to promote/demote.
3. Replication bump factor calculation is now done by the monitoring thread, not by the user/benchmark thread.