### PR TITLE
Remove tracking of observed IPs

### DIFF
--- a/src/bedrock/kvs/node_join_handler.cpp
+++ b/src/bedrock/kvs/node_join_handler.cpp
@@ -35,18 +35,15 @@ void node_join_handler(
       // gossip the new node address between server nodes to ensure consistency
       for (const auto& global_pair : global_hash_ring_map) {
         GlobalHashRing hash_ring = global_pair.second;
-        std::unordered_set<Address> observed_ip;
 
-        for (const auto& hash_pair : hash_ring) {
-          std::string this_ip = hash_pair.second.get_ip();
+        for (const ServerThread& st : hash_ring.get_unique_servers()) {
           // if the node is not myself and not the newly joined node, send the
           // ip of the newly joined node in case of a race condition
-          if (this_ip.compare(ip) != 0 && this_ip.compare(new_server_ip) != 0 &&
-              observed_ip.find(this_ip) == observed_ip.end()) {
+          std::string server_ip = st.get_ip();
+          if (server_ip.compare(ip) != 0 && server_ip.compare(new_server_ip) != 0) {
             zmq_util::send_string(
                 message,
-                &pushers[hash_pair.second.get_node_join_connect_addr()]);
-            observed_ip.insert(this_ip);
+                &pushers[st.get_node_join_connect_addr()]);
           }
         }
 

--- a/src/bedrock/kvs/self_depart_handler.cpp
+++ b/src/bedrock/kvs/self_depart_handler.cpp
@@ -22,16 +22,10 @@ void self_depart_handler(
 
     for (const auto& global_pair : global_hash_ring_map) {
       GlobalHashRing hash_ring = global_pair.second;
-      std::unordered_set<Address> observed_ip;
 
-      for (const auto& hash_pair : hash_ring) {
-        std::string this_ip = hash_pair.second.get_ip();
-
-        if (observed_ip.find(this_ip) == observed_ip.end()) {
-          zmq_util::send_string(
-              msg, &pushers[hash_pair.second.get_node_depart_connect_addr()]);
-          observed_ip.insert(this_ip);
-        }
+      for (const ServerThread& st : hash_ring.get_unique_servers()) {
+        zmq_util::send_string(
+            msg, &pushers[st.get_node_depart_connect_addr()]);
       }
     }
 

--- a/src/bedrock/kvs/server.cpp
+++ b/src/bedrock/kvs/server.cpp
@@ -96,16 +96,11 @@ void run(unsigned thread_id, Address ip, Address seed_ip,
     for (const auto& global_pair : global_hash_ring_map) {
       unsigned tier_id = global_pair.first;
       GlobalHashRing hash_ring = global_pair.second;
-      std::unordered_set<Address> observed_ip;
 
-      for (const auto& hash_pair : hash_ring) {
-        std::string server_ip = hash_pair.second.get_ip();
-        if (server_ip.compare(ip) != 0 &&
-            observed_ip.find(server_ip) == observed_ip.end()) {
-          zmq_util::send_string(
-              std::to_string(kSelfTierId) + ":" + ip,
-              &pushers[hash_pair.second.get_node_join_connect_addr()]);
-          observed_ip.insert(server_ip);
+      for (const ServerThread& st : hash_ring.get_unique_servers()) {
+        if (st.get_ip().compare(ip) != 0) {
+          zmq_util::send_string(std::to_string(kSelfTierId) + ":" + ip,
+              &pushers[st.get_node_join_connect_addr()]);
         }
       }
     }

--- a/src/bedrock/monitor/stats_helpers.cpp
+++ b/src/bedrock/monitor/stats_helpers.cpp
@@ -13,34 +13,31 @@ void collect_internal_stats(
     OccupancyStat& memory_tier_occupancy, OccupancyStat& ebs_tier_occupancy,
     AccessStat& memory_tier_access, AccessStat& ebs_tier_access) {
   std::unordered_map<Address, KeyRequest> addr_request_map;
-  
+
   for (const auto& global_pair : global_hash_ring_map) {
     unsigned tier_id = global_pair.first;
     auto hash_ring = global_pair.second;
-    std::unordered_set<Address> observed_ip;
 
-    for (const auto hash_pair : hash_ring) {
-      Address server_ip = hash_pair.second.get_ip();
-      if (observed_ip.find(server_ip) == observed_ip.end()) {
-        for (unsigned i = 0; i < kTierDataMap[tier_id].thread_number_; i++) {
-          Key key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
-                    std::to_string(i) + "_" + std::to_string(tier_id) + "_stat";
-          prepare_metadata_get_request(key, global_hash_ring_map[1],
-                                       local_hash_ring_map[1], addr_request_map,
-                                       mt, rid);
+    for (const ServerThread& st : hash_ring.get_unique_servers()) {
+      std::string server_ip = st.get_ip();
 
-          key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
-                std::to_string(i) + "_" + std::to_string(tier_id) + "_access";
-          prepare_metadata_get_request(key, global_hash_ring_map[1],
-                                       local_hash_ring_map[1], addr_request_map,
-                                       mt, rid);
-          key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
-                std::to_string(i) + "_" + std::to_string(tier_id) + "_size";
-          prepare_metadata_get_request(key, global_hash_ring_map[1],
-                                       local_hash_ring_map[1], addr_request_map,
-                                       mt, rid);
-        }
-        observed_ip.insert(server_ip);
+      for (unsigned i = 0; i < kTierDataMap[tier_id].thread_number_; i++) {
+        Key key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
+          std::to_string(i) + "_" + std::to_string(tier_id) + "_stat";
+        prepare_metadata_get_request(key, global_hash_ring_map[1],
+            local_hash_ring_map[1], addr_request_map,
+            mt, rid);
+
+        key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
+          std::to_string(i) + "_" + std::to_string(tier_id) + "_access";
+        prepare_metadata_get_request(key, global_hash_ring_map[1],
+            local_hash_ring_map[1], addr_request_map,
+            mt, rid);
+        key = std::string(kMetadataIdentifier) + "_" + server_ip + "_" +
+          std::to_string(i) + "_" + std::to_string(tier_id) + "_size";
+        prepare_metadata_get_request(key, global_hash_ring_map[1],
+            local_hash_ring_map[1], addr_request_map,
+            mt, rid);
       }
     }
   }

--- a/src/bedrock/monitor/storage_policy.cpp
+++ b/src/bedrock/monitor/storage_policy.cpp
@@ -41,7 +41,7 @@ void storage_policy(
 
     if (time_elapsed > kGracePeriod) {
       // pick a random ebs node and send remove node command
-      auto node = next(begin(global_hash_ring_map[2]),
+      auto node = next(global_hash_ring_map[2].begin(),
                        rand() % global_hash_ring_map[2].size())
                       ->second;
       remove_node(logger, node, "ebs", removing_ebs_node, pushers,

--- a/src/bedrock/route/membership_handler.cpp
+++ b/src/bedrock/route/membership_handler.cpp
@@ -28,19 +28,14 @@ void membership_handler(
         for (const auto& global_pair : global_hash_ring_map) {
           unsigned tier_id = global_pair.first;
           auto hash_ring = global_pair.second;
-          std::unordered_set<Address> observed_ip;
 
-          for (const auto& hash_pair : hash_ring) {
-            std::string server_ip = hash_pair.second.get_ip();
-
+          for (const ServerThread& st : hash_ring.get_unique_servers()) {
             // if the node is not the newly joined node, send the ip of the
             // newly joined node
-            if (server_ip.compare(new_server_ip) != 0 &&
-                observed_ip.find(server_ip) == observed_ip.end()) {
+            if (st.get_ip().compare(new_server_ip) != 0) {
               zmq_util::send_string(
                   std::to_string(tier) + ":" + new_server_ip,
-                  &pushers[hash_pair.second.get_node_join_connect_addr()]);
-              observed_ip.insert(server_ip);
+                  &pushers[st.get_node_join_connect_addr()]);
             }
           }
         }

--- a/src/bedrock/route/seed_handler.cpp
+++ b/src/bedrock/route/seed_handler.cpp
@@ -13,18 +13,11 @@ void seed_handler(
   for (const auto& global_pair : global_hash_ring_map) {
     unsigned tier_id = global_pair.first;
     auto hash_ring = global_pair.second;
-    std::unordered_set<Address> observed_ip;
 
-    for (const auto& hash_pair : hash_ring) {
-      std::string thread_ip = hash_pair.second.get_ip();
-
-      if (observed_ip.find(thread_ip) == observed_ip.end()) {
+    for (const ServerThread& st : hash_ring.get_unique_servers()) {
         TierMembership_Tier* tier = membership.add_tiers();
         tier->set_tier_id(tier_id);
-        tier->add_ips(thread_ip);
-
-        observed_ip.insert(thread_ip);
-      }
+        tier->add_ips(st.get_ip());
     }
   }
 

--- a/src/include/common.hpp
+++ b/src/include/common.hpp
@@ -94,16 +94,15 @@ inline void prepare_get_tuple(KeyRequest& req, Key key) {
   tuple->set_key(key);
 }
 
-inline void prepare_put_tuple(KeyRequest& req, Key key,
-                              std::string value, unsigned long long timestamp) {
+inline void prepare_put_tuple(KeyRequest& req, Key key, std::string value,
+                              unsigned long long timestamp) {
   KeyTuple* tp = req.add_tuples();
   tp->set_key(key);
   tp->set_value(value);
   tp->set_timestamp(timestamp);
 }
 
-inline void push_request(const KeyRequest& req,
-                         zmq::socket_t& socket) {
+inline void push_request(const KeyRequest& req, zmq::socket_t& socket) {
   std::string serialized_req;
   req.SerializeToString(&serialized_req);
   zmq_util::send_string(serialized_req, &socket);
@@ -117,4 +116,4 @@ inline RequestType get_request_type(const std::string& type_str) {
   return type;
 }
 
-#endif // SRC_INCLUDE_COMMON_HPP_
+#endif  // SRC_INCLUDE_COMMON_HPP_

--- a/src/include/hash_ring.hpp
+++ b/src/include/hash_ring.hpp
@@ -6,33 +6,34 @@
 
 template <typename H>
 class HashRing : public ConsistentHashMap<ServerThread, H> {
-  public: 
-    HashRing() {}
+ public:
+  HashRing() {}
 
-    ~HashRing() {}
+  ~HashRing() {}
 
-  public: 
-    std::pair<typename ConsistentHashMap<ServerThread, H>::iterator, bool> insert(ServerThread st) {
-      auto result = ConsistentHashMap<ServerThread, H>::insert(st);
+ public:
+  std::pair<typename ConsistentHashMap<ServerThread, H>::iterator, bool> insert(
+      ServerThread st) {
+    auto result = ConsistentHashMap<ServerThread, H>::insert(st);
 
-      if (result.second) {
-        unique_servers.insert(st);
-      }
-
-      return result;
+    if (result.second) {
+      unique_servers.insert(st);
     }
 
-    void erase(ServerThread st) {
-      unique_servers.erase(st);
-      ConsistentHashMap<ServerThread, H>::erase(st);
-    }
+    return result;
+  }
 
-    std::unordered_set<ServerThread, ThreadHash> get_unique_servers() {
-      return unique_servers;
-    }
+  void erase(ServerThread st) {
+    unique_servers.erase(st);
+    ConsistentHashMap<ServerThread, H>::erase(st);
+  }
 
-  private:
-    std::unordered_set<ServerThread, ThreadHash> unique_servers;
+  std::unordered_set<ServerThread, ThreadHash> get_unique_servers() {
+    return unique_servers;
+  }
+
+ private:
+  std::unordered_set<ServerThread, ThreadHash> unique_servers;
 };
 
 typedef HashRing<GlobalHasher> GlobalHashRing;
@@ -109,7 +110,8 @@ inline void warmup_placement_to_defaults(
   }
 }
 
-inline void init_replication(std::unordered_map<Key, KeyInfo>& placement, const Key& key) {
+inline void init_replication(std::unordered_map<Key, KeyInfo>& placement,
+                             const Key& key) {
   for (const unsigned& tier_id : kAllTierIds) {
     placement[key].global_replication_map_[tier_id] =
         kTierDataMap[tier_id].default_replication_;
@@ -117,4 +119,4 @@ inline void init_replication(std::unordered_map<Key, KeyInfo>& placement, const 
   }
 }
 
-#endif // SRC_INCLUDE_HASH_RING_HPP_
+#endif  // SRC_INCLUDE_HASH_RING_HPP_

--- a/src/include/hash_ring.hpp
+++ b/src/include/hash_ring.hpp
@@ -1,8 +1,6 @@
 #ifndef SRC_INCLUDE_HASH_RING_HPP_
 #define SRC_INCLUDE_HASH_RING_HPP_
 
-#include <map>
-
 #include "hashers.hpp"
 #include "utils/consistent_hash_map.hpp"
 
@@ -18,23 +16,23 @@ class HashRing : public ConsistentHashMap<ServerThread, H> {
       auto result = ConsistentHashMap<ServerThread, H>::insert(st);
 
       if (result.second) {
-        unique_ips.insert(st.get_ip());
+        unique_servers.insert(st);
       }
 
       return result;
     }
 
     void erase(ServerThread st) {
-      unique_ips.erase(st.get_ip());
+      unique_servers.erase(st);
       ConsistentHashMap<ServerThread, H>::erase(st);
     }
 
-    std::unordered_set<std::string> get_unique_ips() {
-      return unique_ips;
+    std::unordered_set<ServerThread, ThreadHash> get_unique_servers() {
+      return unique_servers;
     }
 
-  protected:
-    std::unordered_set<std::string> unique_ips;
+  private:
+    std::unordered_set<ServerThread, ThreadHash> unique_servers;
 };
 
 typedef HashRing<GlobalHasher> GlobalHashRing;

--- a/src/include/hashers.hpp
+++ b/src/include/hashers.hpp
@@ -44,4 +44,4 @@ struct LocalHasher {
   }
 };
 
-#endif // SRC_INCLUDE_HASHERS_HPP_
+#endif  // SRC_INCLUDE_HASHERS_HPP_

--- a/src/include/kvs/base_kv_store.hpp
+++ b/src/include/kvs/base_kv_store.hpp
@@ -25,4 +25,4 @@ class KVStore {
   void remove(const K& k) { db.remove(k); }
 };
 
-#endif // SRC_INCLUDE_KVS_BASE_KV_STORE_HPP_
+#endif  // SRC_INCLUDE_KVS_BASE_KV_STORE_HPP_

--- a/src/include/kvs/kvs_handlers.hpp
+++ b/src/include/kvs/kvs_handlers.hpp
@@ -94,9 +94,10 @@ void process_put(const Key& key, const unsigned long long& timestamp,
                  const std::string& value, Serializer* serializer,
                  std::unordered_map<std::string, unsigned>& key_size_map);
 
-bool is_primary_replica(const Key& key, std::unordered_map<Key, KeyInfo>& placement,
-                        std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
-                        std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
-                        ServerThread& st);
+bool is_primary_replica(
+    const Key& key, std::unordered_map<Key, KeyInfo>& placement,
+    std::unordered_map<unsigned, GlobalHashRing>& global_hash_ring_map,
+    std::unordered_map<unsigned, LocalHashRing>& local_hash_ring_map,
+    ServerThread& st);
 
-#endif // SRC_INCLUDE_KVS_KVS_HANDLERS_HPP_
+#endif  // SRC_INCLUDE_KVS_KVS_HANDLERS_HPP_

--- a/src/include/kvs/rc_pair_lattice.hpp
+++ b/src/include/kvs/rc_pair_lattice.hpp
@@ -55,4 +55,4 @@ class ReadCommittedPairLattice : public Lattice<TimestampValuePair<T>> {
   }
 };
 
-#endif // SRC_INCLUDE_KVS_RC_PAIR_LATTICE_HPP_
+#endif  // SRC_INCLUDE_KVS_RC_PAIR_LATTICE_HPP_

--- a/src/include/lattices/base_lattices.hpp
+++ b/src/include/lattices/base_lattices.hpp
@@ -38,4 +38,4 @@ class Lattice {
   void assign(const Lattice<T> &e) { element = e.reveal(); }
 };
 
-#endif // SRC_INCLUDE_LATTICES_BASE_LATTICES_HPP_
+#endif  // SRC_INCLUDE_LATTICES_BASE_LATTICES_HPP_

--- a/src/include/lattices/core_lattices.hpp
+++ b/src/include/lattices/core_lattices.hpp
@@ -150,4 +150,4 @@ class MapLattice : public Lattice<std::unordered_map<K, V>> {
   }
 };
 
-#endif // SRC_INCLUDE_LATTICES_CORE_LATTICES_HPP_
+#endif  // SRC_INCLUDE_LATTICES_CORE_LATTICES_HPP_

--- a/src/include/metadata.hpp
+++ b/src/include/metadata.hpp
@@ -37,4 +37,4 @@ inline bool is_metadata(Key key) {
 // NOTE: This needs to be here because it needs the definition of TierData
 extern std::unordered_map<unsigned, TierData> kTierDataMap;
 
-#endif // SRC_INCLUDE_METADATA_HPP_
+#endif  // SRC_INCLUDE_METADATA_HPP_

--- a/src/include/monitor/monitoring_handlers.hpp
+++ b/src/include/monitor/monitoring_handlers.hpp
@@ -22,10 +22,10 @@ void depart_done_handler(
     bool& removing_ebs_node,
     std::chrono::time_point<std::chrono::system_clock>& grace_start);
 
-void feedback_handler(
-    zmq::socket_t* feedback_puller,
-    std::unordered_map<std::string, double>& user_latency,
-    std::unordered_map<std::string, double>& user_throughput,
-    std::unordered_map<Key, std::pair<double, unsigned>>& latency_miss_ratio_map);
+void feedback_handler(zmq::socket_t* feedback_puller,
+                      std::unordered_map<std::string, double>& user_latency,
+                      std::unordered_map<std::string, double>& user_throughput,
+                      std::unordered_map<Key, std::pair<double, unsigned>>&
+                          latency_miss_ratio_map);
 
-#endif // SRC_INCLUDE_MONITOR_MONITORING_HANDLERS_HPP_
+#endif  // SRC_INCLUDE_MONITOR_MONITORING_HANDLERS_HPP_

--- a/src/include/monitor/monitoring_utils.hpp
+++ b/src/include/monitor/monitoring_utils.hpp
@@ -150,4 +150,4 @@ void remove_node(std::shared_ptr<spdlog::logger> logger, ServerThread& node,
                  std::unordered_map<Address, unsigned>& departing_node_map,
                  MonitoringThread& mt);
 
-#endif // SRC_INCLUDE_MONITOR_MONITORING_UTILS_HPP_
+#endif  // SRC_INCLUDE_MONITOR_MONITORING_UTILS_HPP_

--- a/src/include/monitor/policies.hpp
+++ b/src/include/monitor/policies.hpp
@@ -24,9 +24,8 @@ void movement_policy(
     Address management_address, std::unordered_map<Key, KeyInfo>& placement,
     std::unordered_map<Key, unsigned>& key_access_summary,
     std::unordered_map<Key, unsigned>& key_size, MonitoringThread& mt,
-    SocketCache& pushers,
-    zmq::socket_t& response_puller, std::vector<Address>& routing_address,
-    unsigned& rid);
+    SocketCache& pushers, zmq::socket_t& response_puller,
+    std::vector<Address>& routing_address, unsigned& rid);
 
 void slo_policy(
     std::shared_ptr<spdlog::logger> logger,
@@ -40,6 +39,7 @@ void slo_policy(
     std::unordered_map<Address, unsigned>& departing_node_map,
     SocketCache& pushers, zmq::socket_t& response_puller,
     std::vector<Address>& routing_address, unsigned& rid,
-    std::unordered_map<Key, std::pair<double, unsigned>>& latency_miss_ratio_map);
+    std::unordered_map<Key, std::pair<double, unsigned>>&
+        latency_miss_ratio_map);
 
-#endif // SRC_INCLUDE_MONITOR_POLICIES_HPP_
+#endif  // SRC_INCLUDE_MONITOR_POLICIES_HPP_

--- a/src/include/requests.hpp
+++ b/src/include/requests.hpp
@@ -51,4 +51,4 @@ RES send_request(const REQ& req, zmq::socket_t& sending_socket,
   return response;
 }
 
-#endif // SRC_INCLUDE_REQUESTS_HPP_
+#endif  // SRC_INCLUDE_REQUESTS_HPP_

--- a/src/include/route/routing_handlers.hpp
+++ b/src/include/route/routing_handlers.hpp
@@ -40,4 +40,4 @@ void address_handler(
     PendingMap<std::pair<Address, std::string>>& pending_key_request_map,
     unsigned& seed);
 
-#endif // SRC_INCLUDE_ROUTE_ROUTING_HANDLERS_HPP_
+#endif  // SRC_INCLUDE_ROUTE_ROUTING_HANDLERS_HPP_

--- a/src/include/threads.hpp
+++ b/src/include/threads.hpp
@@ -215,4 +215,4 @@ class UserThread {
   }
 };
 
-#endif // SRC_INCLUDE_THREADS_HPP_
+#endif  // SRC_INCLUDE_THREADS_HPP_

--- a/src/include/types.hpp
+++ b/src/include/types.hpp
@@ -20,4 +20,4 @@ using OccupancyStat = std::unordered_map<
 using AccessStat =
     std::unordered_map<Address, std::unordered_map<unsigned, unsigned>>;
 
-#endif // SRC_INCLUDE_TYPES_HPP_
+#endif  // SRC_INCLUDE_TYPES_HPP_

--- a/src/include/utils/consistent_hash_map.hpp
+++ b/src/include/utils/consistent_hash_map.hpp
@@ -64,4 +64,4 @@ class ConsistentHashMap {
   map_type nodes_;
 };
 
-#endif // SRC_INCLUDE_UTILS_CONSISTENT_HASH_MAP_HPP_
+#endif  // SRC_INCLUDE_UTILS_CONSISTENT_HASH_MAP_HPP_

--- a/src/include/utils/consistent_hash_map.hpp
+++ b/src/include/utils/consistent_hash_map.hpp
@@ -15,7 +15,6 @@ class ConsistentHashMap {
   typedef value_type& reference;
   typedef const value_type& const_reference;
   typedef typename map_type::iterator iterator;
-  typedef typename map_type::reverse_iterator reverse_iterator;
   typedef Alloc allocator_type;
 
  public:
@@ -59,10 +58,6 @@ class ConsistentHashMap {
   iterator begin() { return nodes_.begin(); }
 
   iterator end() { return nodes_.end(); }
-
-  reverse_iterator rbegin() { return nodes_.rbegin(); }
-
-  reverse_iterator rend() { return nodes_.rend(); }
 
  private:
   Hash hasher_;

--- a/src/include/utils/server_utils.hpp
+++ b/src/include/utils/server_utils.hpp
@@ -176,4 +176,4 @@ struct PendingGossip {
   unsigned long long ts_;
 };
 
-#endif // SRC_INCLUDE_UTILS_SERVER_UTILS_HPP_
+#endif  // SRC_INCLUDE_UTILS_SERVER_UTILS_HPP_


### PR DESCRIPTION
* Wrap `ConsistentHashMap` in a data structure that tracks previously seen IP addresses.
* Use the set of unique IPs for iteration instead of the whole virtual hash ring.  

Fixes #87.