### PR TITLE
Adds basic tests for server handlers

### DIFF
--- a/scripts/check-clang.sh
+++ b/scripts/check-clang.sh
@@ -20,8 +20,8 @@ FILES=`git status --porcelain`
 MODIFIED=`git status --porcelain | wc -l`
 
 if [[ $MODIFIED -gt 0 ]]; then
-  echo "clang-format check failed. The following files had style issues:\n"
-  echo $FILES
+  echo -e "clang-format check failed. The following files had style issues:\n"
+  echo -e $FILES
 
   exit 1
 else

--- a/src/bedrock/kvs/rep_factor_change_handler.cpp
+++ b/src/bedrock/kvs/rep_factor_change_handler.cpp
@@ -23,7 +23,6 @@ void rep_factor_change_handler(
     std::unordered_map<Key, unsigned>& key_size_map,
     std::unordered_set<Key>& local_changeset, ServerThread& wt,
     Serializer* serializer, SocketCache& pushers) {
-  // TODO(vikram): make logging in all handlers consistent
   logger->info("Received a replication factor change.");
   if (thread_id == 0) {
     // tell all worker threads about the replication factor change

--- a/src/bedrock/kvs/self_depart_handler.cpp
+++ b/src/bedrock/kvs/self_depart_handler.cpp
@@ -29,7 +29,6 @@ void self_depart_handler(
 
   // thread 0 notifies other nodes in the cluster (of all types) that it is
   // leaving the cluster
-  std::cout << global_hash_ring_map[kSelfTierId].size() << std::endl;
   if (thread_id == 0) {
     std::string msg = std::to_string(kSelfTierId) + ":" + ip;
 

--- a/src/bedrock/kvs/user_request_handler.cpp
+++ b/src/bedrock/kvs/user_request_handler.cpp
@@ -90,6 +90,7 @@ void user_request_handler(
           auto ts = generate_timestamp(time_diff, wt.get_tid());
 
           process_put(key, ts, tuple.value(), serializer, key_size_map);
+          local_changeset.insert(key);
           tp->set_error(0);
         } else {
           logger->error("Unknown request type {} in user request handler.",

--- a/tests/bedrock/kvs/run_server_handler_tests.cpp
+++ b/tests/bedrock/kvs/run_server_handler_tests.cpp
@@ -28,6 +28,7 @@
 #include "test_node_depart_handler.hpp"
 #include "test_node_join_handler.hpp"
 #include "test_self_depart_handler.hpp"
+#include "test_user_request_handler.hpp"
 
 unsigned kDefaultLocalReplication = 1;
 unsigned kSelfTierId = 1;

--- a/tests/bedrock/kvs/test_gossip_handler.hpp
+++ b/tests/bedrock/kvs/test_gossip_handler.hpp
@@ -1,0 +1,62 @@
+//  Copyright 2018 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "kvs/kvs_handlers.hpp"
+
+TEST_F(ServerHandlerTest, SimpleGossipReceive) {
+  Key key = "key";
+  std::string value = "value";
+  std::string put_request = put_key_request(key, value, ip);
+
+  unsigned total_access = 0;
+  unsigned seed = 0;
+  unsigned error;
+  auto now = std::chrono::system_clock::now();
+
+  EXPECT_EQ(local_changeset.size(), 0);
+
+  gossip_handler(seed, put_request, global_hash_ring_map, local_hash_ring_map,
+                 key_size_map, pending_gossip_map, placement, wt, serializer,
+                 pushers);
+
+  EXPECT_EQ(pending_gossip_map.size(), 0);
+  EXPECT_EQ(serializer->get(key, error).reveal().value, value);
+}
+
+TEST_F(ServerHandlerTest, GossipUpdate) {
+  Key key = "key";
+  std::string value = "value1";
+  serializer->put(key, value, (unsigned)0);
+
+  value = "value2";
+
+  std::string put_request = put_key_request(key, value, ip);
+
+  unsigned total_access = 0;
+  unsigned seed = 0;
+  unsigned error;
+  auto now = std::chrono::system_clock::now();
+
+  EXPECT_EQ(local_changeset.size(), 0);
+
+  gossip_handler(seed, put_request, global_hash_ring_map, local_hash_ring_map,
+                 key_size_map, pending_gossip_map, placement, wt, serializer,
+                 pushers);
+
+  EXPECT_EQ(pending_gossip_map.size(), 0);
+  EXPECT_EQ(serializer->get(key, error).reveal().value, value);
+}
+
+// TODO: test pending gossip
+// TODO: test gossip forwarding

--- a/tests/bedrock/kvs/test_rep_factor_change_handler.hpp
+++ b/tests/bedrock/kvs/test_rep_factor_change_handler.hpp
@@ -1,0 +1,17 @@
+//  Copyright 2018 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "kvs/kvs_handlers.hpp"
+
+// TODO: write actual tests

--- a/tests/bedrock/kvs/test_rep_factor_response_handler.hpp
+++ b/tests/bedrock/kvs/test_rep_factor_response_handler.hpp
@@ -1,0 +1,17 @@
+//  Copyright 2018 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "kvs/kvs_handlers.hpp"
+
+// TODO: write actual tests

--- a/tests/bedrock/kvs/test_user_request_handler.hpp
+++ b/tests/bedrock/kvs/test_user_request_handler.hpp
@@ -1,0 +1,117 @@
+//  Copyright 2018 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "kvs/kvs_handlers.hpp"
+
+TEST_F(ServerHandlerTest, UserGetTest) {
+  Key key = "key";
+  std::string value = "value";
+  serializer->put(key, value, 0);
+
+  std::string get_request = get_key_request(key, ip);
+
+  unsigned total_access = 0;
+  unsigned seed = 0;
+  auto now = std::chrono::system_clock::now();
+
+  EXPECT_EQ(local_changeset.size(), 0);
+
+  user_request_handler(total_access, seed, get_request, now, logger,
+                       global_hash_ring_map, local_hash_ring_map, key_size_map,
+                       pending_request_map, key_access_timestamp, placement,
+                       local_changeset, wt, serializer, pushers);
+
+  std::vector<std::string> messages = get_zmq_messages();
+  EXPECT_EQ(messages.size(), 1);
+
+  KeyResponse response;
+  response.ParseFromString(messages[0]);
+
+  EXPECT_EQ(response.response_id(), kRequestId);
+  EXPECT_EQ(response.tuples().size(), 1);
+
+  KeyTuple rtp = response.tuples(0);
+
+  EXPECT_EQ(rtp.key(), key);
+  EXPECT_EQ(rtp.value(), value);
+  EXPECT_EQ(rtp.error(), 0);
+
+  EXPECT_EQ(local_changeset.size(), 0);
+  EXPECT_EQ(total_access, 1);
+  EXPECT_EQ(key_access_timestamp[key].size(), 1);
+}
+
+TEST_F(ServerHandlerTest, UserPutAndGetTest) {
+  Key key = "key";
+  std::string value = "value";
+  std::string put_request = put_key_request(key, value, ip);
+
+  unsigned total_access = 0;
+  unsigned seed = 0;
+  auto now = std::chrono::system_clock::now();
+
+  EXPECT_EQ(local_changeset.size(), 0);
+
+  user_request_handler(total_access, seed, put_request, now, logger,
+                       global_hash_ring_map, local_hash_ring_map, key_size_map,
+                       pending_request_map, key_access_timestamp, placement,
+                       local_changeset, wt, serializer, pushers);
+
+  std::vector<std::string> messages = get_zmq_messages();
+  EXPECT_EQ(messages.size(), 1);
+
+  KeyResponse response;
+  response.ParseFromString(messages[0]);
+
+  EXPECT_EQ(response.response_id(), kRequestId);
+  EXPECT_EQ(response.tuples().size(), 1);
+
+  KeyTuple rtp = response.tuples(0);
+
+  EXPECT_EQ(rtp.key(), key);
+  EXPECT_EQ(rtp.error(), 0);
+
+  EXPECT_EQ(local_changeset.size(), 1);
+  EXPECT_EQ(total_access, 1);
+  EXPECT_EQ(key_access_timestamp[key].size(), 1);
+
+  std::string get_request = get_key_request(key, ip);
+
+  user_request_handler(total_access, seed, get_request, now, logger,
+                       global_hash_ring_map, local_hash_ring_map, key_size_map,
+                       pending_request_map, key_access_timestamp, placement,
+                       local_changeset, wt, serializer, pushers);
+
+  messages = get_zmq_messages();
+  EXPECT_EQ(messages.size(), 2);
+
+  response.ParseFromString(messages[1]);
+
+  EXPECT_EQ(response.response_id(), kRequestId);
+  EXPECT_EQ(response.tuples().size(), 1);
+
+  rtp = response.tuples(0);
+
+  EXPECT_EQ(rtp.key(), key);
+  EXPECT_EQ(rtp.value(), value);
+  EXPECT_EQ(rtp.error(), 0);
+
+  EXPECT_EQ(local_changeset.size(), 1);
+  EXPECT_EQ(total_access, 2);
+  EXPECT_EQ(key_access_timestamp[key].size(), 2);
+}
+
+// TODO: Test key address cache invalidation
+// TODO: Test replication factor request and making the request pending
+// TODO: Test metadata operations -- does this matter?

--- a/tests/mock/mock_utils.cpp
+++ b/tests/mock/mock_utils.cpp
@@ -33,6 +33,8 @@ ServerThreadSet MockHashRingUtil::get_responsible_threads(
     std::unordered_map<Key, KeyInfo>& placement, SocketCache& pushers,
     const std::vector<unsigned>& tier_ids, bool& succeed, unsigned& seed) {
   ServerThreadSet threads;
+  succeed = true;
+
   threads.insert(ServerThread("127.0.0.1", 0));
   return threads;
 }

--- a/tests/test_all.cpp
+++ b/tests/test_all.cpp
@@ -26,9 +26,13 @@
 #include "utils/server_utils.hpp"
 
 #include "bedrock/kvs/server_handler_base.hpp"
+#include "bedrock/kvs/test_gossip_handler.hpp"
 #include "bedrock/kvs/test_node_depart_handler.hpp"
 #include "bedrock/kvs/test_node_join_handler.hpp"
+#include "bedrock/kvs/test_rep_factor_change_handler.hpp"
+#include "bedrock/kvs/test_rep_factor_response_handler.hpp"
 #include "bedrock/kvs/test_self_depart_handler.hpp"
+#include "bedrock/kvs/test_user_request_handler.hpp"
 
 #include "include/lattices/test_bool_lattice.hpp"
 #include "include/lattices/test_map_lattice.hpp"


### PR DESCRIPTION
Doesn't include `rep_factor_change_handler` or `rep_factor_response_handler` because those require more complicated test infrastructure.